### PR TITLE
chore(dev): add newpr.sh helper for PR-only workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@
 5. 推送后开 PR，描述清楚改动动机、影响范围、自测情况。
 6. CI 通过且至少一位 maintainer review 后合并。
 
+> 💡 **快捷脚本**：仓库根目录运行 `./scripts/dev/newpr.sh <branch-name> "PR title"`
+> 自动完成"建分支 → commit → push → 开 PR"全流程，避免直推 main。
+
 ### 开发环境
 见 [docs/WSL_SETUP.md](docs/WSL_SETUP.md) 与 [README.md](README.md#快速开始)。
 
@@ -45,6 +48,9 @@ expected vs. actual behavior, environment details, and logs/screenshots if relev
 4. Use [Conventional Commits](https://www.conventionalcommits.org/).
 5. Open a PR with motivation, scope, and self-test notes.
 6. CI must pass and at least one maintainer must review before merge.
+
+> 💡 **Helper**: From the repo root run `./scripts/dev/newpr.sh <branch-name> "PR title"`
+> to do the whole "branch → commit → push → open PR" dance in one command.
 
 ### Data & Copyright
 This repo does **not** redistribute copyrighted modern punctuated editions

--- a/scripts/dev/newpr.sh
+++ b/scripts/dev/newpr.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# newpr — 一条命令开 PR：建分支 → push → gh pr create
+#
+# Usage:
+#   ./scripts/dev/newpr.sh <branch-name> [PR title]
+#   ./scripts/dev/newpr.sh chore/cleanup-deps
+#   ./scripts/dev/newpr.sh fix/cors-default "fix(cors): tighten default origins"
+#
+# Recommended branch naming:
+#   feat/<topic>      —— 新功能
+#   fix/<topic>       —— bug 修复
+#   chore/<topic>     —— 工程/构建
+#   docs/<topic>      —— 文档
+#   refactor/<topic>  —— 重构
+#   test/<topic>      —— 测试
+#
+# 工作流（per CONTRIBUTING.md）：每次改动都通过 PR，不 push main。
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  cat <<EOF
+Usage: $0 <branch-name> [PR title]
+
+Examples:
+  $0 chore/slim-deps
+  $0 fix/typo-readme "docs: fix typo in README"
+
+Don't forget: commit your changes first; this script then creates a branch
+from your current commits, pushes it, and opens a PR.
+EOF
+  exit 1
+fi
+
+BRANCH="$1"
+TITLE="${2:-}"
+
+# 必须在 main 上才能基于 main 拉新分支（避免基于杂分支）
+CURRENT="$(git symbolic-ref --short HEAD)"
+if [[ "$CURRENT" != "main" ]]; then
+  echo "⚠️  当前在 '$CURRENT'，本脚本期望从 main 拉分支"
+  read -r -p "继续从 '$CURRENT' 拉？[y/N] " ans
+  [[ "$ans" =~ ^[Yy]$ ]] || exit 1
+fi
+
+# 检查工作树有未提交改动
+if [[ -z "$(git status --porcelain)" ]]; then
+  echo "⚠️  工作树没有未提交改动；脚本会建空分支但 PR 会被 GitHub 拒绝"
+  read -r -p "继续？[y/N] " ans
+  [[ "$ans" =~ ^[Yy]$ ]] || exit 1
+fi
+
+echo "→ 切到新分支 $BRANCH"
+git checkout -b "$BRANCH"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "→ 自动 git add + commit"
+  git add -A
+  git commit -m "${TITLE:-WIP: $BRANCH}"
+fi
+
+echo "→ push 到 origin/$BRANCH"
+git push -u origin "$BRANCH"
+
+echo "→ gh pr create"
+if [[ -n "$TITLE" ]]; then
+  gh pr create --title "$TITLE" --body "Auto-created via scripts/dev/newpr.sh."
+else
+  gh pr create --fill
+fi
+
+echo "✓ Done. 等 CI 通过、自审，再 \`gh pr merge\` 或在 GitHub 上 merge。"


### PR DESCRIPTION
## 改动 / Summary

- 新增 \`scripts/dev/newpr.sh\`：一条命令完成"建分支 → commit → push → 开 PR"
- \`CONTRIBUTING.md\` 双语部分加快捷脚本说明

## 动机 / Motivation

我们已切换到 **PR-only 工作流**（不再直接 push main）。日常每个小改动手动跑五条命令成本太高，容易回滚到老习惯。这个脚本让"开 PR"的成本接近于"git push"，养成习惯。

## 使用 / Usage

```bash
# 改完代码后
./scripts/dev/newpr.sh chore/typo-fix "docs: fix typo in README"
```

脚本会：
1. 验证当前分支（默认要求在 main）
2. 切到新分支
3. \`git add -A\` + commit（如有未提交改动）
4. push
5. \`gh pr create\`

## 自测 / Self-test

✅ \`shellcheck scripts/dev/newpr.sh\` 通过
✅ \`bash -n scripts/dev/newpr.sh\` 通过
✅ 手动跑过：从 main → \`./scripts/dev/newpr.sh chore/dev-newpr-helper "..."\` 创建了**这个 PR 本身**

## 范围 / Scope

- 不动业务代码
- 不改 CI
- 仅新增 1 个脚本 + 改 CONTRIBUTING.md