### PR TITLE
fix(deps): bump python-jose & python-multipart (CVE-2024-33664, CVE-2024-24762)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,9 +14,9 @@ asyncpg==0.29.0
 redis>=5.0.0  # 包含异步支持
 
 # 认证和安全
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]>=3.4.0
 passlib[bcrypt]==1.7.4
-python-multipart==0.0.6
+python-multipart>=0.0.18
 bcrypt==4.1.1
 
 # 速率限制和中间件


### PR DESCRIPTION
Closes #32.

## 改动 / Summary

- \`python-jose[cryptography]\` 3.3.0 → **>=3.4.0**（修 CVE-2024-33664 算法混淆）
- \`python-multipart\` 0.0.6 → **>=0.0.18**（修 CVE-2024-24762 拒绝服务）

## 自测 / Self-test

✅ 本地 \`pip install -r backend/requirements.txt\` 解析无冲突
✅ Backend smoke tests 4/4 通过
✅ 没有 import 层 / API 层 breaking change（jose 3.4 是 minor，向后兼容；multipart 0.0.x 系列 API 一致）

## 范围 / Scope

仅 \`backend/requirements.txt\` 一行改动 ×2。