### PR TITLE
chore(lint): clean up ruff F841 / E712 warnings

### DIFF
--- a/backend/app/api/v1/admin/routes.py
+++ b/backend/app/api/v1/admin/routes.py
@@ -231,7 +231,7 @@ async def get_system_stats(
     # 用户统计
     total_users = (await db.execute(select(func.count(User.id)))).scalar() or 0
     active_users = (await db.execute(
-        select(func.count(User.id)).where(User.is_active == True)
+        select(func.count(User.id)).where(User.is_active)
     )).scalar() or 0
     admin_users = (await db.execute(
         select(func.count(User.id)).where(User.role == UserRole.ADMIN)

--- a/backend/app/api/v1/collab/project_routes.py
+++ b/backend/app/api/v1/collab/project_routes.py
@@ -280,7 +280,7 @@ async def update_project_info(
     更新项目基本信息（标题、描述、状态、可见性）
     需要编辑权限
     """
-    project = await get_project_with_permission(
+    await get_project_with_permission(
         project_id=project_id,
         current_user=current_user,
         db=db,
@@ -328,7 +328,7 @@ async def update_project_data(
     更新项目核心数据（校勘数据等）
     需要编辑权限
     """
-    project = await get_project_with_permission(
+    await get_project_with_permission(
         project_id=project_id,
         current_user=current_user,
         db=db,
@@ -369,7 +369,7 @@ async def set_project_visibility(
     设置项目可见性
     只有所有者可以修改
     """
-    project = await check_project_owner(
+    await check_project_owner(
         project_id=project_id,
         current_user=current_user,
         db=db,
@@ -383,7 +383,7 @@ async def set_project_visibility(
         )
 
     service = get_project_service(db)
-    updated = await service.update_project(
+    await service.update_project(
         project_id=project_id,
         user_id=current_user.id,
         visibility=vis,
@@ -404,7 +404,7 @@ async def delete_project(
     """
     删除项目（只有所有者可以删除）
     """
-    project = await check_project_owner(
+    await check_project_owner(
         project_id=project_id,
         current_user=current_user,
         db=db,

--- a/backend/app/api/v1/collab/share_routes.py
+++ b/backend/app/api/v1/collab/share_routes.py
@@ -301,7 +301,7 @@ async def list_comments(
     """
     获取项目评论列表
     """
-    project = await get_project_with_permission(
+    await get_project_with_permission(
         project_id=project_id,
         current_user=current_user,
         db=db,
@@ -334,7 +334,7 @@ async def add_comment(
     添加评论
     需要是项目成员
     """
-    project = await get_project_with_permission(
+    await get_project_with_permission(
         project_id=project_id,
         current_user=current_user,
         db=db,
@@ -374,7 +374,7 @@ async def edit_comment(
     编辑评论（只能编辑自己的评论）
     """
     # 检查项目访问权限
-    project = await get_project_with_permission(
+    await get_project_with_permission(
         project_id=project_id,
         current_user=current_user,
         db=db,
@@ -429,7 +429,7 @@ async def delete_comment(
     删除评论（只能删除自己的评论，管理员可删除任何评论）
     """
     # 检查项目访问权限
-    project = await get_project_with_permission(
+    await get_project_with_permission(
         project_id=project_id,
         current_user=current_user,
         db=db,
@@ -480,7 +480,7 @@ async def list_edit_history(
     """
     获取项目编辑历史
     """
-    project = await get_project_with_permission(
+    await get_project_with_permission(
         project_id=project_id,
         current_user=current_user,
         db=db,

--- a/backend/app/api/v1/comparison/definitive_generator.py
+++ b/backend/app/api/v1/comparison/definitive_generator.py
@@ -13,7 +13,6 @@ PUNCT_MARKS = set('。，、；：？！""''（）《》【】「」『』．·�
 
 def find_actual_position(text: str, clean_pos: int) -> int:
     """将纯文本位置转换为实际字符位置"""
-    actual_pos = 0
     clean_count = 0
     for i, char in enumerate(text):
         if clean_count == clean_pos:

--- a/backend/app/api/v1/comparison/export_routes.py
+++ b/backend/app/api/v1/comparison/export_routes.py
@@ -41,7 +41,7 @@ async def export_collation_notes(request: ExportCollationNotesRequest):
         aligned_segments = collation_service._global_char_alignment(normalized_text1, normalized_text2)
 
         # 3. 计算统计信息
-        statistics = collation_service._compute_alignment_statistics(
+        collation_service._compute_alignment_statistics(
             aligned_segments, normalized_text1, normalized_text2
         )
 

--- a/backend/app/services/cbeta_service.py
+++ b/backend/app/services/cbeta_service.py
@@ -955,8 +955,8 @@ class CBETAService:
                 if elem.tag == f"{{{TEI_NS}}}app":
                     # 这是一个校勘条目
                     lem_elem = elem.find('tei:lem', ns)
-                    rdg_elems = elem.findall('tei:rdg', ns)
-                    note_elem = elem.find('tei:note', ns)
+                    elem.findall('tei:rdg', ns)
+                    elem.find('tei:note', ns)
 
                     if collecting and lem_elem is not None:
                         lem_text = norm(''.join(lem_elem.itertext()))

--- a/backend/app/services/lineage_service.py
+++ b/backend/app/services/lineage_service.py
@@ -204,7 +204,7 @@ class VersionLineageService:
         # 而 similarity_matrix 包含所有版本（底本+校本）
         error_matrix = shared_errors.get('matrix', [])
         error_names = shared_errors.get('names', [])
-        error_details = shared_errors.get('details', {})
+        shared_errors.get('details', {})
 
         # 构建名称到索引的映射（用于共同讹误矩阵）
         error_name_to_idx = {name: idx for idx, name in enumerate(error_names)}
@@ -222,14 +222,14 @@ class VersionLineageService:
                 # 确定方向（年代早→晚）
                 if year1 < year2:
                     source, target = v1, v2
-                    source_idx, target_idx = i, j
+                    _source_idx, _target_idx = i, j
                 elif year1 > year2:
                     source, target = v2, v1
-                    source_idx, target_idx = j, i
+                    _source_idx, _target_idx = j, i
                 else:
                     # 年代相同，按名称顺序（仍然尝试创建关联）
                     source, target = v1, v2
-                    source_idx, target_idx = i, j
+                    _source_idx, _target_idx = i, j
 
                 # 计算传承置信度
                 similarity = similarity_matrix[i][j] if similarity_matrix else 0

--- a/backend/app/services/phylogeny_service.py
+++ b/backend/app/services/phylogeny_service.py
@@ -402,7 +402,6 @@ class PhylogenyAnalysisService:
                 if "yanwen" in categories:
                     # 衍文的位置用插入点之前的底本位置表示
                     pos_in_block = 0
-                    seg1_idx = 0
 
                     for seg in segments1:
                         seg_type = seg.get("type", "")
@@ -431,7 +430,6 @@ class PhylogenyAnalysisService:
                             base_pos += len(seg_text)
 
                     # 更简单的方法：直接遍历 segments2
-                    insert_pos = 0  # 用于标记衍文位置
                     for seg_idx, seg in enumerate(segments2):
                         seg_type = seg.get("type", "")
                         seg_text = seg.get("text", "")

--- a/backend/app/services/punctuation_transfer_service.py
+++ b/backend/app/services/punctuation_transfer_service.py
@@ -238,7 +238,7 @@ class PunctuationTransferService:
             位置映射字典: {源位置: 目标位置或None}
         """
         position_mapping: Dict[int, Optional[int]] = {}
-        source_len = len(source_text)
+        len(source_text)
         target_len = len(target_text)
 
         matcher = difflib.SequenceMatcher(None, source_text, target_text, autojunk=False)

--- a/backend/app/services/sutra_reading_service.py
+++ b/backend/app/services/sutra_reading_service.py
@@ -347,7 +347,7 @@ class SutraReadingService:
             if juan_text:
                 # 获取卷标题
                 jhead = juan_text.find('div', class_='jhead')
-                juan_title = jhead.get_text(strip=True) if jhead else f"卷第{juan_num}"
+                jhead.get_text(strip=True) if jhead else f"卷第{juan_num}"
 
                 # 获取所有段落
                 all_paragraphs = juan_text.find_all('p', class_='normal')

--- a/backend/app/services/text_compare.py
+++ b/backend/app/services/text_compare.py
@@ -84,7 +84,6 @@ class TextComparisonService:
             标点差异信息
         """
         # 提取标点符号位置
-        punct_marks = PUNCTUATION_SET
 
         # 移除标点后的文本
         clean_text1 = strip_punctuation_and_whitespace(text1)


### PR DESCRIPTION
Closes #27.

## 改动 / Summary

- F841 共 26 处：删除未使用的变量绑定，保留产生副作用的右侧调用（多数是 \`await get_project_with_permission(...)\` 用于权限校验）
- E712 共 1 处：\`User.is_active == True\` → \`User.is_active\`

## 自测 / Self-test

✅ \`ruff check app/ --select F841,E712\` → All checks passed
✅ Backend smoke tests 4/4 通过
✅ \`git diff\` 人肉过了一遍，全是机械改动；权限校验调用全保留

## 行为零改动

每处 \`变量 = await func(...)\` 改成 \`await func(...)\`，仅删去变量名；await 调用本身（包括其抛 HTTP 异常的副作用）完整保留。