### PR TITLE
ci: bump GitHub Actions to v6 (Node 24 compat)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     name: Backend lint (ruff)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -43,10 +43,10 @@ jobs:
     name: Backend smoke tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -71,10 +71,10 @@ jobs:
     name: Frontend type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
@@ -106,7 +106,7 @@ jobs:
     name: Gitleaks secret scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
Closes #33.

## 改动 / Summary

升级 GitHub Actions 到 Node 20→24 兼容版本：

- \`actions/checkout@v4\` → **@v6** (×4 处)
- \`actions/setup-python@v5\` → **@v6** (×2 处)
- \`actions/setup-node@v4\` → **@v6** (×1 处)
- \`gitleaks/gitleaks-action@v2\` → 保持（v2 当前仍是最新）

## 动机

CI 每次都警告 \"Node.js 20 actions are deprecated. Will be forced to Node.js 24 by June 2nd, 2026.\"。提前升避免临到截止再改。

## 自测

CI 跑通即验证。如果 v6 有 breaking change 会立刻在 PR 上看到。

## 注

Dependabot 之前为这三个开过独立 PR (#1/#2/#3)，本 PR 一次性覆盖；合后可关掉那 3 个 Dependabot PR。