### PR TITLE
docs: add AUTH/COLLAB/ADMIN module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ This repo does **not** redistribute copyrighted modern punctuated editions.
 
 - 中文完整文档 / Full Chinese docs · [docs/README.zh-CN.md](docs/README.zh-CN.md)
 - 架构设计 / Architecture · [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- 认证模块 / Auth · [docs/AUTH.md](docs/AUTH.md)
+- 协作模块 / Collaboration · [docs/COLLAB.md](docs/COLLAB.md)
+- 管理员模块 / Admin · [docs/ADMIN.md](docs/ADMIN.md)
 - 部署清单 / Deployment · [docs/DEPLOYMENT_CHECKLIST.md](docs/DEPLOYMENT_CHECKLIST.md)
 - WSL 环境 · [docs/WSL_SETUP.md](docs/WSL_SETUP.md)
 - 安全策略 / Security · [SECURITY.md](SECURITY.md)

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -1,0 +1,81 @@
+# 管理员模块 / Admin Module
+
+> 路由前缀 / Route prefix: `/api/v1/admin`
+> 源码 / Source: `backend/app/api/v1/admin/`
+
+**面向**：自部署平台的 sysadmin / 站长。普通研究用户不需要这块。
+
+**权限**：所有端点都要求 `current_user.role == UserRole.ADMIN`。普通注册用户没有 admin 权限。
+
+## 端点一览 / Endpoints
+
+| Method | Path | 用途 |
+|---|---|---|
+| `GET` | `/users` | 列出所有用户（支持分页、搜索） |
+| `GET` | `/users/{id}` | 用户详情 |
+| `PUT` | `/users/{id}` | 改用户信息（含 `role`、`is_active`） |
+| `DELETE` | `/users/{id}` | 删除用户（软删 / 硬删按实现） |
+| `GET` | `/stats` | 系统统计：总用户数 / 活跃用户 / 管理员数 / 项目数等 |
+
+## 怎么把一个用户提升为 admin / How to promote
+
+v0.1.0 没有"创建第一个 admin"的引导流程——常规思路：
+
+### 方案 A：直接改数据库（最直接）
+
+```sql
+UPDATE users SET role = 'admin' WHERE email = 'you@example.com';
+```
+
+### 方案 B：写一个 alembic 迁移 / 脚本（更工程化）
+
+可以放到 `backend/scripts/promote_to_admin.py`（roadmap 待加）。
+
+### 方案 C：让首个注册用户自动是 admin
+
+这是常见 self-host 套路，但目前未实现。如果你部署给学校 / 寺院 / 研究所自用，建议用方案 A 一次性搞定。
+
+## 端点细节 / Endpoint Details
+
+### `GET /users`
+
+```
+Query params:
+  skip: int = 0
+  limit: int = 50
+  search?: str        # 模糊匹配 email / full_name
+  role?: viewer|editor|admin
+  is_active?: bool
+
+Response:
+  { items: [...], total: 123 }
+```
+
+### `GET /stats`
+
+```
+Response:
+  {
+    total_users: 234,
+    active_users: 198,
+    admin_users: 3,
+    total_projects: 89,
+    ...
+  }
+```
+
+适合做后台 dashboard。
+
+## 安全建议 / Security Notes
+
+1. **管理员账号不要日常使用**——单独建一个 admin 账号，只在管理时切。
+2. **公网部署**：在 nginx 层把 `/api/v1/admin/*` 限制到内网 IP / VPN，多一层防护。
+3. **审计**：所有 admin 操作都应该走 EditHistory 记录。当前 v0.1.0 这部分**未实现**，是一个 roadmap 项。
+
+## 客户端 / Frontend
+
+前端 admin 页面在 `frontend/src/pages/admin/`，菜单入口默认对**非 admin** 隐藏。
+
+---
+
+*相关文档 / See also: [`AUTH.md`](AUTH.md) · [`COLLAB.md`](COLLAB.md) · [`SECURITY.md`](../SECURITY.md)*

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,0 +1,92 @@
+# 认证模块 / Authentication Module
+
+> 路由前缀 / Route prefix: `/api/v1/auth`
+> 源码 / Source: `backend/app/api/v1/auth/`
+
+本平台采用 **JWT** 双令牌方案：短期 `access_token`（默认 30 分钟）+ 长期 `refresh_token`（默认 7 天）。
+
+## 端点一览 / Endpoints
+
+| Method | Path | 用途 | 是否需要登录 |
+|---|---|---|---|
+| `POST` | `/register` | 注册新用户 | ❌ |
+| `POST` | `/login` | 邮箱+密码登录，返回双令牌 | ❌ |
+| `POST` | `/refresh` | 用 refresh_token 换新 access_token | ❌ |
+| `POST` | `/logout` | 注销（client 端清 token；server 当前无黑名单） | ✅ |
+| `GET` | `/me` | 获取当前用户信息 | ✅ |
+| `PUT` | `/me` | 更新姓名 / 邮箱 / 头像等 | ✅ |
+| `PUT` | `/password` | 修改密码（需提供旧密码） | ✅ |
+
+## 流程图 / Flow
+
+```
+┌──────────────┐   POST /register / /login   ┌──────────────┐
+│   Client     │ ───────────────────────────▶│   Backend    │
+│              │   { email, password }       │              │
+│              │ ◀───────────────────────────│   FastAPI    │
+│              │   { access_token (30min),   │              │
+│              │     refresh_token (7d) }    │              │
+└──────────────┘                             └──────────────┘
+       │
+       │  以后每个请求加 Header:
+       │  Authorization: Bearer <access_token>
+       ▼
+┌──────────────────────────────────────────┐
+│  当 access_token 401（过期）            │
+│    POST /refresh + refresh_token        │
+│    → 拿到新的 access_token，继续        │
+│  当 refresh_token 也过期 → 重新 /login  │
+└──────────────────────────────────────────┘
+```
+
+## 数据模型 / Schemas
+
+参考 `backend/app/api/v1/auth/schemas.py`。关键字段：
+
+```python
+RegisterRequest:  email, password (>=6), full_name?
+LoginRequest:     email, password
+TokenResponse:    access_token, refresh_token, token_type="bearer"
+UserResponse:     id, email, full_name, role, is_active, created_at
+```
+
+## 部署侧注意 / Deployment notes
+
+⚠️ 公网部署前，**必须**完成（详见 [`SECURITY.md`](../SECURITY.md)）：
+
+1. `SECRET_KEY` 用强随机值（`python -c "import secrets; print(secrets.token_urlsafe(48))"`）
+2. 反向代理（nginx/Caddy）启用 HTTPS——JWT 在明文传输下可被窃听
+3. 在反向代理或 FastAPI 层为 `/auth/login` 与 `/auth/register` 启用更严的 rate limit（默认是全局 60/min；登录/注册建议 5/min + 失败锁定）
+4. 当前**无 server 端 token 撤销黑名单**——一旦签发，access_token 在 30 分钟内有效；refresh_token 在 7 天内有效。token 失窃只能等过期。
+   未来 roadmap：JTI + Redis 黑名单，参考 [#34 / Roadmap](../ROADMAP.md)。
+
+## 客户端用法 / Client usage
+
+参考 `frontend/src/services/authApi.ts` 与 `frontend/src/store/authStore.ts`。
+
+```typescript
+// 登录
+const { access_token, refresh_token } = await authApi.login(email, password)
+localStorage.setItem('access_token', access_token)
+localStorage.setItem('refresh_token', refresh_token)
+
+// 后续请求（axios 拦截器自动加 Authorization Header）
+await api.get('/multi-collation/projects')
+
+// access 401 时，axios 拦截器自动 /refresh 重试
+```
+
+## 常见问题 / FAQ
+
+**Q: 我能直接 `localStorage.getItem('access_token')` 吗？**
+A: 可以，但请意识到 XSS 风险。当前是 client-stored token；roadmap 中考虑改成 httpOnly cookie + CSRF token 方案。
+
+**Q: 注册需要邮箱验证吗？**
+A: v0.1.0 不验证。生产部署前建议加邮箱链接确认，避免恶意批量注册。
+
+**Q: 怎么改密码长度等校验规则？**
+A: `backend/app/api/v1/auth/schemas.py` 里 `RegisterRequest.password` 的 Pydantic 验证器。
+
+---
+
+*相关文档 / See also: [`COLLAB.md`](COLLAB.md) · [`ADMIN.md`](ADMIN.md) · [`SECURITY.md`](../SECURITY.md)*

--- a/docs/COLLAB.md
+++ b/docs/COLLAB.md
@@ -1,0 +1,101 @@
+# 协作模块 / Collaboration Module
+
+> 路由前缀 / Route prefix: `/api/v1/collab`
+> 源码 / Source: `backend/app/api/v1/collab/`
+
+让多位研究者在同一个校勘项目上共同工作：项目所有权、成员邀请、角色权限、批注、编辑历史。
+
+## 协作模型 / Model
+
+```
+User
+ ├─ owns ──→ Project (visibility: private | shared | public)
+ │            │
+ │            ├─ shared with ──→ Member (role: viewer | editor | admin)
+ │            │
+ │            ├─ has ──────────→ Comment (位置定位、可回复、可编辑)
+ │            │
+ │            └─ tracks ───────→ EditHistory (谁、何时、改了什么)
+ │
+ └─ shared as Member ─→ Project (其他人的项目)
+```
+
+### 角色 / Roles
+
+| 角色 | 能做 |
+|---|---|
+| **owner** | 删除项目、改可见性、邀请/移除成员、所有 editor 权限 |
+| **admin** | 改成员角色（除 owner）、所有 editor 权限 |
+| **editor** | 改项目数据、写/改自己的评论 |
+| **viewer** | 只读项目数据、看评论 |
+
+## 端点一览 / Endpoints
+
+### 项目 / Projects (`project_routes.py`)
+
+| Method | Path | 权限 |
+|---|---|---|
+| `GET` | `/projects` | 列出**我**拥有的项目 |
+| `GET` | `/projects/shared` | 列出**别人**共享给我的项目 |
+| `GET` | `/projects/all` | 我能看到的全部（拥有 + 共享） |
+| `POST` | `/projects` | 创建项目（自动成为 owner） |
+| `GET` | `/projects/{id}` | 项目详情（需 viewer+） |
+| `PUT` | `/projects/{id}` | 改标题/描述/状态/可见性（需 editor+） |
+| `PUT` | `/projects/{id}/data` | 改核心校勘数据（需 editor+） |
+| `PUT` | `/projects/{id}/visibility` | 改可见性（仅 owner） |
+| `DELETE` | `/projects/{id}` | 删除项目（仅 owner） |
+
+### 成员与共享 / Members & Sharing (`share_routes.py`)
+
+| Method | Path | 权限 |
+|---|---|---|
+| `GET` | `/projects/{id}/members` | 列出成员（需 viewer+） |
+| `POST` | `/projects/{id}/share` | 邀请用户为成员（需 admin/owner） |
+| `PUT` | `/projects/{id}/share/{user_id}` | 改成员角色（需 admin/owner） |
+| `DELETE` | `/projects/{id}/share/{user_id}` | 取消共享（需 admin/owner） |
+
+### 评论 / Comments
+
+| Method | Path | 权限 |
+|---|---|---|
+| `GET` | `/projects/{id}/comments` | 列出评论（需 viewer+） |
+| `POST` | `/projects/{id}/comments` | 加评论（需 viewer+） |
+| `PUT` | `/projects/{id}/comments/{cid}` | 改评论（仅作者） |
+| `DELETE` | `/projects/{id}/comments/{cid}` | 删评论（作者或 admin/owner） |
+
+### 历史 / History
+
+| Method | Path | 权限 |
+|---|---|---|
+| `GET` | `/projects/{id}/history` | 编辑历史（需 viewer+） |
+
+## 典型流程 / Typical Flow
+
+```
+Alice 创建项目 X，自动是 owner
+  ↓
+Alice 邀请 Bob (editor) 和 Carol (viewer)
+  ↓
+Bob 修改了底本 → 历史里出现 "Bob edited base text"
+Carol 在某处加了评论 "此字疑误，参《大正藏》异文"
+  ↓
+Alice 看历史，approve Bob 的改动
+  ↓
+Alice 把项目改为 public 可见 → 任何登录用户可只读
+```
+
+## 数据模型 / Schemas
+
+参考 `backend/app/api/v1/collab/schemas.py` 与 `backend/app/models/collaboration.py`。
+
+## 已知限制 / Known Limitations (v0.1.0)
+
+- ❌ **没有邀请通知**：邀请后被邀请者不会收到邮件 / 站内信。需手动告知。
+- ❌ **没有实时协作锁**：两人同时改 `/data` 会互相覆盖，最后写的赢。Roadmap 中考虑乐观锁 + WebSocket 通知。
+- ❌ **评论不能 @mention**
+
+这些都在 [`ROADMAP.md`](../ROADMAP.md) 的 v0.3 阶段。
+
+---
+
+*相关文档 / See also: [`AUTH.md`](AUTH.md) · [`ADMIN.md`](ADMIN.md)*


### PR DESCRIPTION
Closes #31.

## 改动 / Summary

新增 3 份模块文档（覆盖之前没文档的后端模块）：

- \`docs/AUTH.md\` — JWT 双令牌流程、端点表、前端 token 用法、部署注意
- \`docs/COLLAB.md\` — 协作模型（owner/admin/editor/viewer 4 角色）、项目/成员/评论/历史 4 类端点、典型流程
- \`docs/ADMIN.md\` — 管理员模块说明、"如何把第一个用户提升为 admin" 三种方案、安全建议

\`README.md\` 文档区加 3 个链接。

## 内容亮点

- **如实写明 v0.1.0 已知限制**（无邀请通知、无协作锁、无审计日志），把 roadmap 联系起来
- **每份文档都不只是端点列表**，还有流程图、典型场景、安全提醒、前端入口

## 自测

✅ 链接全部能跳（AUTH ↔ COLLAB ↔ ADMIN ↔ SECURITY ↔ ROADMAP）
✅ Markdown 渲染检查（GitHub 预览）
✅ 端点对照源码核对一遍，无遗漏