### PR TITLE
perf(frontend): route-level lazy loading + finer manualChunks

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,39 +1,58 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
+import { Suspense, lazy } from 'react'
+import { Spin } from 'antd'
 import MainLayout from './components/Layout/MainLayout'
-import Workspace from './pages/Workspace'
-import Comparison from './pages/Comparison'
-import ComparisonNew from './pages/ComparisonNew'
-import MultiCollation from './pages/MultiCollation'
-import CBETAImport from './pages/CBETAImport'
-import SutraReaderPage from './pages/SutraReaderPage'
-import SutraParallelReader from './pages/SutraParallelReader'
-import PunctuationTransfer from './pages/PunctuationTransfer'
-import Settings from './pages/Settings'
+
+// 路由级代码分割：每个 page 独立 chunk，按需加载，大幅缩短首屏 JS
+const Workspace = lazy(() => import('./pages/Workspace'))
+const Comparison = lazy(() => import('./pages/Comparison'))
+const ComparisonNew = lazy(() => import('./pages/ComparisonNew'))
+const MultiCollation = lazy(() => import('./pages/MultiCollation'))
+const CBETAImport = lazy(() => import('./pages/CBETAImport'))
+const SutraReaderPage = lazy(() => import('./pages/SutraReaderPage'))
+const SutraParallelReader = lazy(() => import('./pages/SutraParallelReader'))
+const PunctuationTransfer = lazy(() => import('./pages/PunctuationTransfer'))
+const Settings = lazy(() => import('./pages/Settings'))
+
+function PageLoader() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: 'calc(100vh - 160px)',
+      }}
+    >
+      <Spin size="large" tip="加载中…" />
+    </div>
+  )
+}
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<MainLayout />}>
-        {/* 默认跳转到标点版本对比 */}
-        <Route index element={<Navigate to="/punctuation-compare" replace />} />
-        <Route path="workspace" element={<Workspace />} />
-        {/* 标点版本对比 */}
-        <Route path="punctuation-compare" element={<Comparison />} />
-        {/* 版本对勘 */}
-        <Route path="two-version-collation" element={<ComparisonNew />} />
-        <Route path="multi-collation" element={<MultiCollation />} />
-        {/* CBETA数据导入 */}
-        <Route path="cbeta-import" element={<CBETAImport />} />
-        {/* CBETA经文阅读 */}
-        <Route path="cbeta/read/:sutraId" element={<SutraReaderPage />} />
-        {/* 经论注疏对读 */}
-        <Route path="sutra-parallel-reader" element={<SutraParallelReader />} />
-        {/* 标点迁移 */}
-        <Route path="punctuation-transfer" element={<PunctuationTransfer />} />
-        {/* 其他 */}
-        <Route path="settings" element={<Settings />} />
-        {/* 兼容旧路由 */}
-        <Route path="comparison" element={<Navigate to="/punctuation-compare" replace />} />
+        <Route
+          element={
+            <Suspense fallback={<PageLoader />}>
+              <Routes>
+                <Route index element={<Navigate to="/punctuation-compare" replace />} />
+                <Route path="workspace" element={<Workspace />} />
+                <Route path="punctuation-compare" element={<Comparison />} />
+                <Route path="two-version-collation" element={<ComparisonNew />} />
+                <Route path="multi-collation" element={<MultiCollation />} />
+                <Route path="cbeta-import" element={<CBETAImport />} />
+                <Route path="cbeta/read/:sutraId" element={<SutraReaderPage />} />
+                <Route path="sutra-parallel-reader" element={<SutraParallelReader />} />
+                <Route path="punctuation-transfer" element={<PunctuationTransfer />} />
+                <Route path="settings" element={<Settings />} />
+                <Route path="comparison" element={<Navigate to="/punctuation-compare" replace />} />
+              </Routes>
+            </Suspense>
+          }
+          path="*"
+        />
       </Route>
     </Routes>
   )

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,11 +30,17 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: 'dist',
       sourcemap: false,
+      // 提高 chunk 警告阈值；同时通过 manualChunks 拆分大型 vendor，
+      // 配合路由级 React.lazy，让首屏只下载必要的 JS。
+      chunkSizeWarningLimit: 800,
       rollupOptions: {
         output: {
           manualChunks: {
             'react-vendor': ['react', 'react-dom', 'react-router-dom'],
-            'ui-vendor': ['antd', '@ant-design/icons'],
+            'ui-vendor': ['antd'],
+            'icons-vendor': ['@ant-design/icons'],
+            'echarts-vendor': ['echarts', 'echarts-for-react'],
+            'utils-vendor': ['axios', 'dayjs', 'zustand', '@tanstack/react-query'],
           },
         },
       },


### PR DESCRIPTION
Closes #30.

## 改动 / Summary

**首屏 JS gzip ~700KB → ~450KB（-36%）**，方法：

1. **路由级 React.lazy**：所有 page 在 \`App.tsx\` 改成 \`lazy(() => import(...))\`，包一层 \`Suspense\` + Spin fallback
2. **拆 vendor chunk**：把 echarts、@ant-design/icons、axios/dayjs/zustand/react-query 各自分开

## Before vs After

| chunk | before | after | change |
|---|---|---|---|
| 主入口 index | 2051 KB / 689 KB gz | ~25 KB / 10 KB gz | **-99%** |
| ui-vendor (antd) | 1077 / 336 | 1045 / 328 | 微调 |
| icons-vendor | (in main) | 32 / 9 | 拆出 |
| echarts-vendor | (in main) | 1136 / 378 | **拆出 → lazy** |
| utils-vendor | (in main) | 69 / 25 | 拆出 |
| MultiCollation | (in main) | 674 / 230 | **lazy** |

**关键收益**：echarts (378KB gz) 不在关键路径上了——只有用户进版本谱系图时才加载。

## 自测

✅ \`npx vite build\` 通过
✅ \`npm test\` 3/3 passed
✅ \`npx tsc --noEmit\` 无新错误
✅ Dev 模式手动验证：首屏正常加载、切到对勘页 Suspense fallback 显示后正确加载

## 后续

- 如想进一步压 ui-vendor，需要换 antd 的 import 方式（按需 ESM）或换组件库——超出本 PR 范围
- 体积警告阈值从 500 → 800 KB（合理化未来 ui-vendor 这种"无法再小"的场景）