### PR TITLE
feat(i18n): bootstrap react-i18next + MainLayout migration

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,9 +15,12 @@
         "dayjs": "^1.11.10",
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.5",
+        "i18next": "^26.0.8",
+        "i18next-browser-languagedetector": "^8.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-draggable": "^4.5.0",
+        "react-i18next": "^17.0.6",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.20.0",
         "zustand": "^4.4.7"
@@ -450,9 +453,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4356,6 +4359,15 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmmirror.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4364,6 +4376,43 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.0.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.8.tgz",
+      "integrity": "sha512-BRzLom0mhDhV9v0QhgUUHWQJuwFmnr1194xEcNLYD6ym8y8s542n4jXUvRLnhNTbh9PmpU6kGZamyuGHQMsGjw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/ignore": {
@@ -6765,6 +6814,33 @@
         "react-dom": ">= 16.3.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.6.tgz",
+      "integrity": "sha512-WzJ6SMKF+GTD7JZZqxSR1AKKmXjaSu39sClUrNlwxS4Tl7a99O+ltFy6yhPMO+wgZuxpQjJ2PZkfrQKmAqrLhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.0.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmmirror.com/react-is/-/react-is-18.3.1.tgz",
@@ -7525,7 +7601,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8434,6 +8510,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,9 +22,12 @@
     "dayjs": "^1.11.10",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.5",
+    "i18next": "^26.0.8",
+    "i18next-browser-languagedetector": "^8.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-draggable": "^4.5.0",
+    "react-i18next": "^17.0.6",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.20.0",
     "zustand": "^4.4.7"

--- a/frontend/src/components/Layout/MainLayout.tsx
+++ b/frontend/src/components/Layout/MainLayout.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Outlet, useNavigate, useLocation } from 'react-router-dom'
-import { Layout, Menu, theme, Button, Tooltip, Space } from 'antd'
+import { Layout, Menu, theme, Button, Tooltip, Space, Dropdown } from 'antd'
 import {
   FileTextOutlined,
   DiffOutlined,
@@ -12,9 +12,12 @@ import {
   CompressOutlined,
   ReadOutlined,
   SwapOutlined,
+  GlobalOutlined,
 } from '@ant-design/icons'
 import type { MenuProps } from 'antd'
+import { useTranslation } from 'react-i18next'
 import { useSettingsStore } from '../../store/settingsStore'
+import { supportedLanguages } from '../../i18n'
 
 const { Header, Content, Sider } = Layout
 
@@ -34,19 +37,10 @@ function getItem(
   } as MenuItem
 }
 
-const menuItems: MenuItem[] = [
-  getItem('工作台', '/workspace', <AppstoreOutlined />),
-  getItem('CBETA导入', '/cbeta-import', <DatabaseOutlined />),
-  getItem('版本对勘', '/multi-collation', <BookOutlined />),
-  getItem('标点版本对比', '/punctuation-compare', <DiffOutlined />),
-  getItem('标点迁移', '/punctuation-transfer', <SwapOutlined />),
-  getItem('经论注疏对读', '/sutra-parallel-reader', <ReadOutlined />),
-  getItem('设置', '/settings', <SettingOutlined />),
-]
-
 export default function MainLayout() {
   const navigate = useNavigate()
   const location = useLocation()
+  const { t, i18n } = useTranslation()
   const [collapsed, setCollapsed] = useState(false)
   const {
     token: { colorBgContainer, borderRadiusLG, colorPrimary },
@@ -56,9 +50,25 @@ export default function MainLayout() {
   const { settings, toggleZenMode } = useSettingsStore()
   const { zenMode } = settings.ui
 
+  const menuItems: MenuItem[] = [
+    getItem(t('menu.workspace'), '/workspace', <AppstoreOutlined />),
+    getItem(t('menu.cbetaImport'), '/cbeta-import', <DatabaseOutlined />),
+    getItem(t('menu.multiCollation'), '/multi-collation', <BookOutlined />),
+    getItem(t('menu.punctuationCompare'), '/punctuation-compare', <DiffOutlined />),
+    getItem(t('menu.punctuationTransfer'), '/punctuation-transfer', <SwapOutlined />),
+    getItem(t('menu.sutraParallelReader'), '/sutra-parallel-reader', <ReadOutlined />),
+    getItem(t('menu.settings'), '/settings', <SettingOutlined />),
+  ]
+
   const handleMenuClick: MenuProps['onClick'] = (e) => {
     navigate(e.key)
   }
+
+  const languageMenuItems: MenuProps['items'] = supportedLanguages.map((lng) => ({
+    key: lng.code,
+    label: lng.label,
+    onClick: () => i18n.changeLanguage(lng.code),
+  }))
 
   // 专注模式下显示浮动工具条
   if (zenMode) {
@@ -66,7 +76,7 @@ export default function MainLayout() {
       <Layout style={{ minHeight: '100vh' }}>
         {/* 浮动工具条 */}
         <div className="zen-mode-toolbar">
-          <Tooltip title="退出专注模式">
+          <Tooltip title={t('actions.exitZenMode')}>
             <Button
               type="text"
               icon={<CompressOutlined />}
@@ -114,14 +124,21 @@ export default function MainLayout() {
               fontFamily: 'var(--font-family-heading)',
             }}
           >
-            佛典标点与校勘研究平台
+            {t('app.title')}
           </h1>
         </div>
 
         {/* 右侧工具栏 */}
         <Space size="small">
+          {/* 语言切换 */}
+          <Dropdown menu={{ items: languageMenuItems, selectable: true, selectedKeys: [i18n.language] }} placement="bottomRight">
+            <Tooltip title={t('actions.switchLanguage')}>
+              <Button type="text" icon={<GlobalOutlined />} />
+            </Tooltip>
+          </Dropdown>
+
           {/* 专注模式按钮 */}
-          <Tooltip title="专注模式">
+          <Tooltip title={t('actions.zenMode')}>
             <Button
               type="text"
               icon={<ExpandOutlined />}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,51 @@
+/**
+ * i18n 入口 / i18n entry
+ *
+ * 用法 / Usage:
+ *   import { useTranslation } from 'react-i18next'
+ *   const { t } = useTranslation()
+ *   t('menu.workspace')   // → "工作台" or "Workbench"
+ *
+ * 切换语言 / Switch language:
+ *   i18n.changeLanguage('en')  // 写到 localStorage，自动持久化
+ *
+ * 添加新翻译 / Adding translations:
+ *   编辑 src/i18n/locales/<lang>/common.json
+ *   逐步把组件里的硬编码中文换成 t('namespace.key')
+ */
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+
+import zhCN from './locales/zh-CN/common.json'
+import en from './locales/en/common.json'
+
+export const resources = {
+  'zh-CN': { common: zhCN },
+  en: { common: en },
+} as const
+
+export const supportedLanguages = [
+  { code: 'zh-CN', label: '中文' },
+  { code: 'en', label: 'English' },
+] as const
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: 'zh-CN',
+    defaultNS: 'common',
+    supportedLngs: ['zh-CN', 'en'],
+    interpolation: {
+      escapeValue: false, // React 已经做了 XSS 转义
+    },
+    detection: {
+      order: ['localStorage', 'navigator'],
+      caches: ['localStorage'],
+      lookupLocalStorage: 'i18nextLng',
+    },
+  })
+
+export default i18n

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1,0 +1,28 @@
+{
+  "app": {
+    "title": "Buddhist Text Collation Platform",
+    "tagline": "佛典标点与校勘研究平台"
+  },
+  "menu": {
+    "workspace": "Workbench",
+    "cbetaImport": "CBETA Import",
+    "multiCollation": "Multi-edition Collation",
+    "punctuationCompare": "Punctuation Diff",
+    "punctuationTransfer": "Punctuation Transfer",
+    "sutraParallelReader": "Commentary Parallel Reading",
+    "settings": "Settings"
+  },
+  "actions": {
+    "zenMode": "Focus mode",
+    "exitZenMode": "Exit focus mode",
+    "switchLanguage": "Switch language"
+  },
+  "common": {
+    "loading": "Loading…",
+    "save": "Save",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "delete": "Delete",
+    "edit": "Edit"
+  }
+}

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1,0 +1,28 @@
+{
+  "app": {
+    "title": "佛典标点与校勘研究平台",
+    "tagline": "Buddhist Text Collation Platform"
+  },
+  "menu": {
+    "workspace": "工作台",
+    "cbetaImport": "CBETA导入",
+    "multiCollation": "版本对勘",
+    "punctuationCompare": "标点版本对比",
+    "punctuationTransfer": "标点迁移",
+    "sutraParallelReader": "经论注疏对读",
+    "settings": "设置"
+  },
+  "actions": {
+    "zenMode": "专注模式",
+    "exitZenMode": "退出专注模式",
+    "switchLanguage": "切换语言"
+  },
+  "common": {
+    "loading": "加载中…",
+    "save": "保存",
+    "cancel": "取消",
+    "confirm": "确认",
+    "delete": "删除",
+    "edit": "编辑"
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,6 +9,7 @@ import 'dayjs/locale/zh-cn'
 import App from './App'
 import ErrorBoundary from './components/ErrorBoundary'
 import ThemeProvider from './theme/ThemeProvider'
+import './i18n' // i18n 必须在任何使用 useTranslation 的组件之前 init
 import './index.css'
 
 // 配置dayjs


### PR DESCRIPTION
Closes (partial) #34.

## 改动 / Summary

为前端搭好 i18n 脚手架，让后续按 page/component 慢慢迁就好。

### 新增

- \`src/i18n/index.ts\` — i18next + LanguageDetector init，支持 zh-CN / en，localStorage 持久化
- \`src/i18n/locales/zh-CN/common.json\` — 中文（默认 fallback）
- \`src/i18n/locales/en/common.json\` — 英文骨架（菜单、标题、专注模式、通用动词）
- \`src/main.tsx\` — 入口加载 \`'./i18n'\`

### 已迁的样板

\`components/Layout/MainLayout.tsx\`：
- 菜单 7 项全部用 \`t('menu.*')\`
- Header 标题、Tooltip 全部走 i18n
- 顶部新增**语言切换按钮**（地球图标 → 下拉），切完 localStorage 自动记住

### 怎么扩展

```tsx
import { useTranslation } from 'react-i18next'
function MyPage() {
  const { t } = useTranslation()
  return <h1>{t('myPage.title')}</h1>
}
```

并在 \`zh-CN/common.json\` 和 \`en/common.json\` 都加上 key。

## 自测

✅ \`npm test\` 3/3 通过
✅ \`npx vite build\` 通过
✅ Dev 模式手动验证：启动后默认中文；点地球图标切 English，菜单瞬间变英文；刷新仍是英文；再切回中文 OK

## 后续

- 按 [Roadmap v0.3](../../blob/main/ROADMAP.md) 每个 page 一个 PR
- 等核心 page 都迁完，README 加英文版 + 文档双语化