### PR TITLE
fix(types): close out TypeScript strict-mode debt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,10 @@ jobs:
         working-directory: frontend
         run: npm ci --no-audit --no-fund
 
-      # tsc 当前为 advisory 模式：项目存在历史类型债（缺失字段、隐式 any 等），
-      # Vite/esbuild 运行时不受影响。后续清理后可移除 continue-on-error。
-      - name: TypeScript check (advisory)
+      # tsc 已切回严格模式（gating）。如未来出现新的类型债，请在原 PR 中修掉，
+      # 不要回退到 advisory。
+      - name: TypeScript check
         working-directory: frontend
-        continue-on-error: true
         run: npx tsc --noEmit
 
       - name: Lint (advisory)

--- a/frontend/src/components/phylogeny/LineageGraph.tsx
+++ b/frontend/src/components/phylogeny/LineageGraph.tsx
@@ -32,8 +32,10 @@ const calculateYearLevels = (nodes: LineageNode[]): Map<string, number> => {
   const levels = new Map<string, number>()
   if (nodes.length === 0) return levels
 
-  // 按年代排序
-  const sortedYears = [...new Set(nodes.map(n => n.year))].sort((a, b) => a - b)
+  // 按年代排序（year 可能是 number 或 string，统一为 number 比较）
+  const sortedYears = [...new Set(nodes.map(n => n.year))].sort(
+    (a, b) => Number(a) - Number(b)
+  )
 
   // 为每个独特的年代分配层级
   sortedYears.forEach((year, index) => {
@@ -87,7 +89,7 @@ export default function LineageGraph({ lineageData }: LineageGraphProps) {
     const getShortName = createVersionNameSimplifier(12)
 
     // 构建 ECharts 节点数据
-    const graphNodes = nodes.map((node, idx) => {
+    const graphNodes = nodes.map((node) => {
       const system = node.system || '未知'
       const level = yearLevels.get(node.id) || 0
       const systemNodes = systemGroups.get(system) || []
@@ -173,7 +175,7 @@ export default function LineageGraph({ lineageData }: LineageGraphProps) {
             return `
               <div style="font-weight:bold;margin-bottom:4px;">${node.name}</div>
               <div>年代: ${node.year}</div>
-              <div>系统: <span style="color:${getSystemColor(node.system)}">${node.system}</span></div>
+              <div>系统: <span style="color:${getSystemColor(node.system || '未知')}">${node.system || '未知'}</span></div>
               ${node.city ? `<div>刻印地: ${node.city}</div>` : ''}
               ${node.period ? `<div>时期: ${node.period}</div>` : ''}
               ${node.is_ancestor ? '<div style="color:#faad14;margin-top:4px;">祖本</div>' : ''}

--- a/frontend/src/components/phylogeny/types.ts
+++ b/frontend/src/components/phylogeny/types.ts
@@ -53,3 +53,40 @@ export interface PhylogenyAnalysisProps {
 }
 
 export type VariantType = 'error' | 'variant' | 'yantuo' | 'combined'
+
+// ==================== 版本源流图 / Lineage Graph ====================
+
+/**
+ * 单个版本节点
+ */
+export interface LineageNode {
+  id: string
+  name: string
+  year: number | string
+  system?: string
+  city?: string
+  period?: string
+  is_ancestor?: boolean
+}
+
+/**
+ * 版本之间的传承关系（有向边）
+ */
+export interface LineageEdge {
+  source: string
+  target: string
+  confidence: number
+  similarity?: number
+  shared_errors?: number
+  evidence?: string[]
+  is_known?: boolean
+}
+
+/**
+ * 版本源流图完整数据
+ */
+export interface LineageData {
+  nodes: LineageNode[]
+  edges: LineageEdge[]
+  conclusions?: string[]
+}

--- a/frontend/src/pages/MultiCollation.tsx
+++ b/frontend/src/pages/MultiCollation.tsx
@@ -132,15 +132,28 @@ interface PhylogenyNode {
   children: PhylogenyNode[]
 }
 
+interface SharedErrorDetail {
+  position: number
+  base_char: string
+  shared_error_char?: string
+  shared_char?: string
+  category?: string
+}
+
 interface SharedErrors {
   names: string[]
+  // 讹误（默认）
   matrix: number[][]
-  details?: Record<string, Array<{
-    position: number
-    base_char: string
-    shared_error_char: string
-  }>>
+  details?: Record<string, SharedErrorDetail[]>
   total_by_version?: Record<string, number>
+  // 异体字
+  variant_matrix?: number[][]
+  variant_details?: Record<string, SharedErrorDetail[]>
+  variant_total_by_version?: Record<string, number>
+  // 衍脱
+  yantuo_matrix?: number[][]
+  yantuo_details?: Record<string, SharedErrorDetail[]>
+  yantuo_total_by_version?: Record<string, number>
 }
 
 interface MultiCollationResponse {

--- a/frontend/src/pages/multi-collation/types.ts
+++ b/frontend/src/pages/multi-collation/types.ts
@@ -49,17 +49,33 @@ export interface PhylogenyNode {
 }
 
 /**
- * 共同错误
+ * 共同异文详情项（详见 src/types/multiCollation.ts 中同名导出的注释）
+ */
+export interface SharedErrorDetail {
+  position: number
+  base_char: string
+  shared_error_char?: string
+  shared_char?: string
+  category?: string
+}
+
+/**
+ * 共同异文 / Shared variants
  */
 export interface SharedErrors {
   names: string[]
+  // 讹误（默认）
   matrix: number[][]
-  details?: Record<string, Array<{
-    position: number
-    base_char: string
-    shared_error_char: string
-  }>>
+  details?: Record<string, SharedErrorDetail[]>
   total_by_version?: Record<string, number>
+  // 异体字
+  variant_matrix?: number[][]
+  variant_details?: Record<string, SharedErrorDetail[]>
+  variant_total_by_version?: Record<string, number>
+  // 衍脱
+  yantuo_matrix?: number[][]
+  yantuo_details?: Record<string, SharedErrorDetail[]>
+  yantuo_total_by_version?: Record<string, number>
 }
 
 /**

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,8 +5,17 @@
 // 导出版本对勘模块类型
 export * from './multiCollation'
 
-// 导出校勘视图模块类型
-export * from './collationView'
+// 导出校勘视图模块类型（排除与 multiCollation 重名的 InitialHighlight；
+// 校勘视图组件内部使用时直接 import './collationView' 拿原始版）
+export type {
+  CollationViewData,
+  CollationViewProps,
+  DiffNavigation,
+  CharSegment,
+  CollationStatistics,
+  AlignedSentence,
+  SideBySideResult,
+} from './collationView'
 
 // 标点请求
 export interface PunctuationRequest {

--- a/frontend/src/types/multiCollation.ts
+++ b/frontend/src/types/multiCollation.ts
@@ -37,15 +37,34 @@ export interface PhylogenyNode {
   children: PhylogenyNode[]
 }
 
+/**
+ * 共同异文详情项
+ *
+ * 后端历史上字段名变过：旧版返回 `shared_error_char`，新版改用 `shared_char`。
+ * 这里两个都声明为可选，前端代码做 fallback：`detail.shared_error_char ?? detail.shared_char`
+ */
+export interface SharedErrorDetail {
+  position: number
+  base_char: string
+  shared_error_char?: string
+  shared_char?: string
+  category?: string  // 仅 yantuo_details 用：'衍'/'脱' 等
+}
+
 export interface SharedErrors {
   names: string[]
+  // 讹误（默认）
   matrix: number[][]
-  details?: Record<string, Array<{
-    position: number
-    base_char: string
-    shared_error_char: string
-  }>>
+  details?: Record<string, SharedErrorDetail[]>
   total_by_version?: Record<string, number>
+  // 异体字
+  variant_matrix?: number[][]
+  variant_details?: Record<string, SharedErrorDetail[]>
+  variant_total_by_version?: Record<string, number>
+  // 衍脱
+  yantuo_matrix?: number[][]
+  yantuo_details?: Record<string, SharedErrorDetail[]>
+  yantuo_total_by_version?: Record<string, number>
 }
 
 // ==================== API 响应类型 ====================


### PR DESCRIPTION
Closes #28.

## 改动 / Summary

把残留的所有 \`tsc --noEmit\` 错误清掉，**CI 中的 \`continue-on-error: true\` 拿掉**，TypeScript 严格模式正式回归。

### 类型补全

1. **\`types/multiCollation.ts\`** + **\`pages/multi-collation/types.ts\`** + **\`pages/MultiCollation.tsx\`**：
   把 \`SharedErrors\` 接口补齐成实际后端返回的形状：
   - \`variant_matrix / variant_details / variant_total_by_version\`（异体字）
   - \`yantuo_matrix / yantuo_details / yantuo_total_by_version\`（衍脱）
   - 新增 \`SharedErrorDetail\` 类型，兼容新旧字段名（\`shared_char\` vs \`shared_error_char\`）

2. **\`components/phylogeny/types.ts\`**：
   补 \`LineageData\` / \`LineageNode\` / \`LineageEdge\` 三个接口（LineageGraph 之前从这里 import 但 module 里没有）

3. **\`components/phylogeny/LineageGraph.tsx\`**：
   - \`year\` 排序用 \`Number()\` 转换（year 类型是 \`number | string\`）
   - 删除未使用的 \`idx\` 参数
   - \`node.system\` 可能为 undefined，传 \`getSystemColor()\` 前用 \`?? '未知'\`

4. **\`types/index.ts\`**：
   原来对 \`./multiCollation\` 和 \`./collationView\` 都做 \`export *\`，两边都导出 \`InitialHighlight\` 但定义不同 → 冲突。
   改为对 collationView 做精确白名单导出，跳过冲突的 \`InitialHighlight\`（collation-view 内部直接 \`import from './collationView'\` 拿原版）。

### CI

\`frontend-typecheck\` job 的 \`tsc --noEmit\` 步骤拿掉 \`continue-on-error: true\`，**严格 gating 恢复**。以后出现类型债**会直接 fail CI**。

## Before vs After

| 状态 | 错误数 | CI gating |
|---|---|---|
| Before | ~36 | advisory |
| After | **0** | **strict** ✓ |

## 自测

✅ \`npx tsc --noEmit\` → 0 errors
✅ \`npx vite build\` 通过
✅ \`npm test\` 3/3 passed