### PR TITLE
chore(readme): remove v0.1.0 OCR-not-bundled note

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,6 @@
 
 ---
 
-> 💡 **当前版本说明** / Note on v0.1.0
->
-> 本开源版**未集成第三方付费 OCR**（如 gj.cool）。如需图片→文字流程，请用任意外部 OCR 工具识别后，再把文本导入本平台校勘流程。
->
-> The OCR digitization workbench from the internal version is **not** bundled.
-> Use any external OCR tool and import recognized text into the collation flow.
-
----
-
 ## 界面预览 / Screenshots
 
 ### 经论注疏对读 / Commentary Parallel Reading


### PR DESCRIPTION
## Summary

Removes the floating "💡 当前版本说明 / Note on v0.1.0" callout from the top of `README.md`.

## Why

The note was useful at v0.1.0 launch to set expectations about the OCR digitization workbench not being bundled in the OSS distribution. By now (post-launch) the same information is available from the feature docs directly, and the prominent callout at the top reads more as "we're missing something" framing rather than the intentional scope decision it actually was.

The collation workflow accepts text from any source (CBETA, DILA, manual transcription, or output from any OCR tool), so the practical guidance — "import recognized text into the collation flow" — is already evident from the import UI and supporting docs.

## What changed

`README.md`: removes 9 lines (the bilingual blockquote + its surrounding `---` separator), keeping the screenshots section flowing naturally after the doc-link summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)