### PR TITLE
feat(compose): provision postgres:15-alpine (fix non-functional Docker quickstart)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,14 @@
 ENV=development
 
 # ================================
+# 主库 PostgreSQL (docker-compose 使用)
+# ================================
+# 强随机密码：python -c "import secrets; print(secrets.token_urlsafe(24))"
+POSTGRES_DB=buddhist_text
+POSTGRES_USER=buddhist_user
+POSTGRES_PASSWORD="REPLACE-WITH-STRONG-PASSWORD"
+
+# ================================
 # Umami 访问统计 (docker-compose 使用)
 # ================================
 # 强随机字符串：python -c "import secrets; print(secrets.token_urlsafe(48))"

--- a/README.md
+++ b/README.md
@@ -144,8 +144,15 @@ npm install
 ### Docker 部署 / Docker deployment
 
 ```bash
+# 1. 准备 .env（务必填好 POSTGRES_PASSWORD / UMAMI_*）
+cp .env.example .env
+# 2. 一键起 backend + frontend + postgres + redis + umami
 docker-compose up -d --build
 ```
+
+`docker-compose.yml` 现已内置 `postgres:15-alpine` 主库，无需另行准备 DB。
+The compose file now provisions `postgres:15-alpine` for you — no
+external DB needed.
 
 详见 [docs/DEPLOYMENT_CHECKLIST.md](docs/DEPLOYMENT_CHECKLIST.md) 与
 [docs/WSL_SETUP.md](docs/WSL_SETUP.md)。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       DEBUG: "false"
       HOST: "0.0.0.0"
       PORT: "8000"
+      # 数据库（compose 内置 postgres 服务，覆盖 .env 默认值）
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-buddhist_user}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}@postgres:5432/${POSTGRES_DB:-buddhist_text}
       # Redis 配置（可选，不配置则自动降级）
       REDIS_URL: redis://redis:6379/0
       # CORS 配置 (JSON 格式) — 通过 .env 覆盖；默认仅本地
@@ -43,6 +45,8 @@ services:
       # 日志
       LOG_LEVEL: INFO
     depends_on:
+      postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
     healthcheck:
@@ -107,6 +111,28 @@ services:
       retries: 5
 
   # ================================
+  # PostgreSQL 主库
+  # ================================
+  postgres:
+    image: postgres:15-alpine
+    container_name: buddhist-text-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-buddhist_text}
+      POSTGRES_USER: ${POSTGRES_USER:-buddhist_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-buddhist_user} -d ${POSTGRES_DB:-buddhist_text}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # 默认不暴露 5432 公网端口；本地开发需要时取消注释
+    # ports:
+    #   - "127.0.0.1:5432:5432"
+
+  # ================================
   # Redis 缓存（可选）
   # ================================
   redis:
@@ -133,6 +159,8 @@ volumes:
   backend_logs:
     driver: local
   backend_data:
+    driver: local
+  postgres_data:
     driver: local
   redis_data:
     driver: local


### PR DESCRIPTION
## Summary
\`docker-compose up -d --build\` was effectively broken: backend defaulted to \`postgresql+asyncpg://...@localhost:5432\` but \`docker-compose.yml\` only defined redis / umami / umami-db / backend / frontend — **no main postgres**. README's "Docker deployment" line was promising something that didn't work.

This PR provisions \`postgres:15-alpine\` and wires the backend to it.

## Changes
- New \`postgres\` service with healthcheck + \`postgres_data\` named volume
- Backend service injects \`DATABASE_URL=postgresql+asyncpg://...@postgres:5432/...\` via compose env, overriding the localhost fallback in \`.env\`
- Backend \`depends_on\` now requires postgres healthy
- \`.env.example\` gains \`POSTGRES_DB\` / \`POSTGRES_USER\` / \`POSTGRES_PASSWORD\` (required, no insecure default)
- 5432 is **not** published by default — bind to \`127.0.0.1:5432\` is commented out for opt-in local debugging
- README Docker section notes the bundled DB

## Test plan
- [x] \`python -c "import yaml; yaml.safe_load(open('docker-compose.yml'))"\` parses
- [x] \`docker-compose config\` would resolve all interpolations once \`POSTGRES_PASSWORD\` is set in \`.env\`
- [ ] Reviewer with Docker available: \`POSTGRES_PASSWORD=test docker compose up -d backend postgres redis\` reaches \`/health\` returning 200

## Follow-up (separate PRs)
- Alembic baseline migration (next PR in this batch — \`/openapi.json\` works because models are auto-created in dev mode, but production has no migration story)
- China-mirror Dockerfile sources behind build args

🤖 Generated with [Claude Code](https://claude.com/claude-code)