### PR TITLE
chore(docker): default to upstream registries, CN mirrors via build args

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,17 @@ UMAMI_APP_SECRET="REPLACE-WITH-RANDOM-SECRET"
 UMAMI_DB_PASSWORD="REPLACE-WITH-STRONG-PASSWORD"
 
 # ================================
+# 镜像源（可选 / Optional registry mirrors）
+# ================================
+# Defaults pull from upstream Docker Hub / GitHub Container Registry.
+# Mainland-China users can opt into faster mirrors here:
+# UMAMI_IMAGE=ghcr.nju.edu.cn/umami-software/umami:postgresql-latest
+# UMAMI_DB_IMAGE=swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/postgres:15-alpine
+#
+# For Dockerfile builds, pass --build-arg APT_MIRROR=..., PIP_INDEX_URL=...,
+# NODE_IMAGE=..., NGINX_IMAGE=..., NPM_REGISTRY=... — see each Dockerfile header.
+
+# ================================
 # 应用基础配置
 # ================================
 APP_NAME="佛典智能标点与校勘研究平台"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,21 +1,33 @@
+# Default to upstream registries — China-mainland users can opt into
+# faster mirrors via build args:
+#   docker build \
+#     --build-arg APT_MIRROR=https://mirrors.aliyun.com \
+#     --build-arg PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple \
+#     -t buddhist-text-backend backend/
+ARG APT_MIRROR=
+ARG PIP_INDEX_URL=https://pypi.org/simple
+
 FROM python:3.11-slim
 
 LABEL maintainer="Buddhist Text Platform Team"
 LABEL description="Backend service for Buddhist Text Platform"
 
-# 设置工作目录
 WORKDIR /app
 
-# 设置环境变量
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# 使用国内镜像源（解决网络问题）
-RUN sed -i 's|http://deb.debian.org|https://mirrors.aliyun.com|g' /etc/apt/sources.list.d/debian.sources
+# Re-declare ARGs after FROM so they're visible inside the stage.
+ARG APT_MIRROR
+ARG PIP_INDEX_URL
 
-# 安装系统依赖
+# Optional apt mirror swap (no-op when APT_MIRROR is unset).
+RUN if [ -n "$APT_MIRROR" ]; then \
+      sed -i "s|http://deb.debian.org|$APT_MIRROR|g" /etc/apt/sources.list.d/debian.sources; \
+    fi
+
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
@@ -24,20 +36,16 @@ RUN apt-get update && apt-get install -y \
     ghostscript \
     && rm -rf /var/lib/apt/lists/*
 
-# 复制依赖文件
 COPY requirements.txt .
 
-# 安装Python依赖
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --index-url "$PIP_INDEX_URL" -r requirements.txt
 
-# 复制应用代码
 COPY . .
 
-# 创建必要的目录
 RUN mkdir -p uploads exports logs
 
-# 暴露端口
 EXPOSE 8000
 
-# 启动命令（生产环境默认单 worker，避免多进程下的文件存储/内存状态竞态）
+# 单 worker 默认值是因为后端有 in-process 状态（local file caches）；
+# 横向扩展前请先把这些状态搬到 Redis / shared volume。
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
   # Umami 访问统计
   # ================================
   umami:
-    image: ghcr.nju.edu.cn/umami-software/umami:postgresql-latest
+    image: ${UMAMI_IMAGE:-ghcr.io/umami-software/umami:postgresql-latest}
     container_name: buddhist-text-umami
     restart: unless-stopped
     ports:
@@ -95,7 +95,7 @@ services:
         condition: service_healthy
 
   umami-db:
-    image: swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/postgres:15-alpine
+    image: ${UMAMI_DB_IMAGE:-postgres:15-alpine}
     container_name: buddhist-text-umami-db
     restart: unless-stopped
     environment:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,61 +1,56 @@
-# 多阶段构建
+# Default to upstream registries — China-mainland users can opt into
+# faster mirrors via build args:
+#   docker build \
+#     --build-arg NODE_IMAGE=swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/node:20-alpine \
+#     --build-arg NGINX_IMAGE=swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/nginx:alpine \
+#     --build-arg NPM_REGISTRY=https://registry.npmmirror.com \
+#     -t buddhist-text-frontend frontend/
+ARG NODE_IMAGE=node:20-alpine
+ARG NGINX_IMAGE=nginx:alpine
+ARG NPM_REGISTRY=https://registry.npmjs.org
 
-# 开发阶段
-FROM swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/node:20-alpine AS development
+
+# ----- Development stage -----
+FROM ${NODE_IMAGE} AS development
 
 WORKDIR /app
 
-# 设置 npm 国内镜像源（解决网络问题）
-RUN npm config set registry https://registry.npmmirror.com
+ARG NPM_REGISTRY
+RUN npm config set registry "${NPM_REGISTRY}"
 
-# 复制依赖文件
 COPY package*.json ./
-
-# 安装依赖
 RUN npm install
 
-# 复制源代码
 COPY . .
 
-# 暴露端口
 EXPOSE 3000
 
-# 开发命令
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
 
 
-# 构建阶段
-FROM swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/node:20-alpine AS build
+# ----- Build stage -----
+FROM ${NODE_IMAGE} AS build
 
 WORKDIR /app
 
-# 设置 npm 国内镜像源（解决网络问题）
-RUN npm config set registry https://registry.npmmirror.com
+ARG NPM_REGISTRY
+RUN npm config set registry "${NPM_REGISTRY}"
 
-# 复制依赖文件
 COPY package*.json ./
-
-# 安装所有依赖（包括 devDependencies，构建需要）
 RUN npm ci
 
-# 复制源代码
 COPY . .
 
-# 构建应用（跳过 TypeScript 类型检查，直接用 Vite 构建）
+# 跳过 tsc 前置（类型检查由 CI 守门），直接走 vite build。
 RUN npx vite build
 
 
-# 生产阶段
-FROM swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/nginx:alpine AS production
+# ----- Production stage -----
+FROM ${NGINX_IMAGE} AS production
 
-# 复制nginx配置
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-
-# 复制构建产物
 COPY --from=build /app/dist /usr/share/nginx/html
 
-# 暴露端口
 EXPOSE 80
 
-# 启动nginx
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
Both Dockerfiles + \`docker-compose.yml\` hardcoded mainland-China mirrors (aliyun apt, npmmirror.com, ghcr.nju.edu.cn, swr.cn-north-4.myhuaweicloud). That made \`docker build\` impossible-to-slow for anyone outside CN, contradicting our international-contributor goal (README.en.md, P2 of the v0.2 roadmap).

Defaults flipped to upstream; CN mirrors are now opt-in.

## Changes
| File | Default | CN override |
|---|---|---|
| \`backend/Dockerfile\` | upstream debian apt + pypi.org | \`--build-arg APT_MIRROR=https://mirrors.aliyun.com\` + \`--build-arg PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple\` |
| \`frontend/Dockerfile\` | \`node:20-alpine\` + \`nginx:alpine\` + registry.npmjs.org | \`--build-arg NODE_IMAGE=...\` + \`NGINX_IMAGE=...\` + \`NPM_REGISTRY=...\` |
| \`docker-compose.yml\` (umami) | \`ghcr.io/umami-software/umami:postgresql-latest\` | \`UMAMI_IMAGE=...\` env override |
| \`docker-compose.yml\` (umami-db) | \`postgres:15-alpine\` | \`UMAMI_DB_IMAGE=...\` env override |

CN-mainland override examples are documented in \`.env.example\` and at the top of each Dockerfile.

Also added a comment on the \`--workers 1\` CMD pointing to the in-process state issue (separate refactor PR).

## Test plan
- [x] \`python -c "import yaml; yaml.safe_load(open('docker-compose.yml'))"\` parses
- [ ] CI: existing jobs unaffected (no Docker build in CI today)
- [ ] Reviewer (any region): \`docker build backend/\` succeeds with default args

🤖 Generated with [Claude Code](https://claude.com/claude-code)