### PR TITLE
sec(nginx): add CSP + standard security headers

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,6 +8,35 @@ server {
     # 如需更大支持，可按实际目标调高
     client_max_body_size 1g;
 
+    # ------------------------------------------------------------
+    # 安全响应头 / Security headers
+    # ------------------------------------------------------------
+    # 禁止被嵌入到第三方站点 iframe（点击劫持防护）
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    # 禁止 MIME 类型嗅探
+    add_header X-Content-Type-Options "nosniff" always;
+    # 跨站请求只发送 origin，保护用户 URL 隐私
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # 关闭不需要的浏览器特性
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=()" always;
+    # 跨源隔离基础（防 Spectre 类侧信道）
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    # CSP：default-src 'self'；script/style 'unsafe-inline' 是 Ant Design + Vite
+    # 注入运行时样式所需，移除前需先迁出运行时 style；connect-src 含 ws/wss
+    # 给 streaming 接口；img 允许 data:/blob: 给 echarts 导出图片用。
+    add_header Content-Security-Policy "default-src 'self'; \
+script-src 'self' 'unsafe-inline'; \
+style-src 'self' 'unsafe-inline'; \
+img-src 'self' data: blob:; \
+font-src 'self' data:; \
+connect-src 'self' ws: wss:; \
+frame-ancestors 'self'; \
+base-uri 'self'; \
+form-action 'self'; \
+object-src 'none'" always;
+    # NB: HSTS 由前置 Caddy/nginx/Cloudflare 在 HTTPS 出口打，不在镜像内强制，
+    # 避免本地 HTTP 调试被 305 永久重定向锁死。
+
     # Gzip 压缩
     gzip on;
     gzip_vary on;
@@ -17,7 +46,12 @@ server {
     # 静态资源缓存
     location /assets/ {
         expires 1y;
-        add_header Cache-Control "public, immutable";
+        add_header Cache-Control "public, immutable" always;
+        # NB: nginx 中只要 location 里有 `add_header`，server 级别的 add_header
+        # 全部不会被继承——必须在此 location 里把安全头补回来。
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 
     # API 代理到后端
@@ -47,6 +81,9 @@ server {
     location /health {
         access_log off;
         return 200 "healthy\n";
-        add_header Content-Type text/plain;
+        add_header Content-Type text/plain always;
+        # 同上：location 内一旦写 add_header，server 级别全部失效，需补回。
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
     }
 }


### PR DESCRIPTION
## Summary
The container's nginx was returning **zero** security headers — every page shipped without X-Frame-Options, CSP, Referrer-Policy, etc. Adds a conservative baseline.

## Headers added
| Header | Value | Why |
|---|---|---|
| \`X-Frame-Options\` | SAMEORIGIN | Clickjacking defence |
| \`X-Content-Type-Options\` | nosniff | MIME sniffing |
| \`Referrer-Policy\` | strict-origin-when-cross-origin | Don't leak full URLs cross-origin |
| \`Permissions-Policy\` | geolocation/mic/camera/payment/usb \`()\` | Disable unused powerful features |
| \`Cross-Origin-Opener-Policy\` | same-origin | Spectre-class isolation |
| \`Content-Security-Policy\` | \`default-src 'self'\` + minimal allowances | XSS defence (see below) |

## CSP allowances (and what they cost)
- \`script-src 'self' 'unsafe-inline'\` — required by Vite's runtime + Ant Design
- \`style-src 'self' 'unsafe-inline'\` — Ant Design injects runtime CSS
- \`img-src 'self' data: blob:\` — echarts uses \`canvas.toBlob\` for image export
- \`connect-src 'self' ws: wss:\` — streaming endpoints

Tightening \`'unsafe-inline'\` is gated on a CSS-in-JS migration — separate PR.

## nginx footgun caught and handled
\`add_header\` directives inside a \`location\` block **silently drop all server-level \`add_header\`s**. Both \`/assets/\` (Cache-Control) and \`/health\` (Content-Type) had this — security headers would have been **absent** on those responses. Re-added the critical ones inline with a comment.

## What's deliberately NOT here
- **HSTS** — should be set by the HTTPS-terminating front-end (Caddy/nginx/Cloudflare). Setting inside this container would 305-lock local HTTP debugging.

## Test plan
- [x] \`{}\` brace balance preserved
- [ ] CI green
- [ ] Reviewer (with running stack): \`curl -I http://localhost:3000\` shows the headers
- [ ] Reviewer: app loads without console CSP violations (Ant Design pages, echarts export, streaming endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)