### PR TITLE
test(services): extend coverage to punctuation_analysis + text_compare (+35 cases)

### DIFF
--- a/backend/tests/services/test_punctuation_diff_extractor.py
+++ b/backend/tests/services/test_punctuation_diff_extractor.py
@@ -1,0 +1,83 @@
+"""Unit tests for app.services.punctuation_analysis.diff_extractor.
+
+Focus on the cheap-to-test classification helpers — they're what the
+UI uses to label each variation in the punctuation-comparison view.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.punctuation_analysis.diff_extractor import (
+    extract_punctuation_differences,
+    get_diff_type,
+    get_punctuation_category,
+    get_punctuation_name,
+)
+
+
+class TestGetDiffType:
+    def test_empty_first_means_addition(self):
+        assert get_diff_type("", "。") == "新增标点"
+
+    def test_empty_second_means_deletion(self):
+        assert get_diff_type("。", "") == "删除标点"
+
+    def test_different_punctuation_is_replacement(self):
+        assert get_diff_type("，", "。") == "替换标点"
+
+    def test_same_punctuation_with_extra_tail_is_addition(self):
+        # punct1 is a prefix of punct2 → user added marks at the end.
+        assert get_diff_type("。", "。」") == "新增标点"
+
+    def test_same_punctuation_with_missing_tail_is_deletion(self):
+        # punct2 is a prefix of punct1 → user removed trailing marks.
+        assert get_diff_type("。」", "。") == "删除标点"
+
+    def test_partial_overlap_is_replacement(self):
+        # Common prefix exists but neither is a prefix of the other.
+        assert get_diff_type("。」", "。』") == "替换标点"
+
+
+class TestGetPunctuationCategory:
+    @pytest.mark.parametrize("punct", ["，", "。", "？", "！"])
+    def test_known_punct_returns_a_named_category_not_other(self, punct):
+        # Don't pin to specific category strings — those live in constants
+        # and may evolve. Just assert a known mark gets a real category.
+        assert get_punctuation_category(punct, "") != "其他"
+
+    def test_unknown_input_falls_back_to_other(self):
+        assert get_punctuation_category("Z", "") == "其他"
+
+
+class TestGetPunctuationName:
+    def test_no_punct_returns_empty_label(self):
+        assert get_punctuation_name("", "") == "无标点"
+
+    def test_known_punct_yields_human_name(self):
+        # Period is in PUNCTUATION_NAMES; we don't pin the exact string,
+        # only that it's not the raw glyph (i.e. a name was looked up).
+        name = get_punctuation_name("。", "")
+        assert name and name != "。"
+
+    def test_unknown_punct_falls_back_to_glyph(self):
+        # Unknown char: the function returns the first char itself.
+        assert get_punctuation_name("§", "") == "§"
+
+
+class TestExtractPunctuationDifferences:
+    def test_identical_texts_have_no_differences(self):
+        diffs = extract_punctuation_differences(
+            "学而时习之，不亦说乎",
+            "学而时习之，不亦说乎",
+        )
+        assert diffs == []
+
+    def test_single_punctuation_swap_surfaces_one_diff(self):
+        diffs = extract_punctuation_differences(
+            "学而时习之，不亦说乎",
+            "学而时习之。不亦说乎",
+        )
+        assert len(diffs) == 1
+        # Each diff dict must at minimum carry both sides + a type label.
+        d = diffs[0]
+        assert "version1_punct" in d or "punct1" in d  # tolerate either key

--- a/backend/tests/services/test_punctuation_text_utils.py
+++ b/backend/tests/services/test_punctuation_text_utils.py
@@ -1,0 +1,66 @@
+"""Unit tests for app.services.punctuation_analysis.text_utils."""
+from __future__ import annotations
+
+from app.services.punctuation_analysis.text_utils import (
+    build_punctuation_map,
+    normalize_for_comparison,
+    split_into_sentences,
+)
+
+
+class TestNormalizeForComparison:
+    def test_collapses_newlines_to_spaces(self):
+        assert normalize_for_comparison("a\nb\nc") == "a b c"
+
+    def test_collapses_multiple_spaces(self):
+        assert normalize_for_comparison("a    b   c") == "a b c"
+
+    def test_strips_outer_whitespace(self):
+        assert normalize_for_comparison("  hello  ") == "hello"
+
+    def test_empty_input(self):
+        assert normalize_for_comparison("") == ""
+
+
+class TestBuildPunctuationMap:
+    def test_no_punctuation_yields_empty_map(self):
+        # All non-punct chars; nothing to map.
+        assert build_punctuation_map("学而时习之") == {}
+
+    def test_trailing_punctuation_after_each_char(self):
+        # 子，曰：学：
+        # char 0 (子) followed by ，
+        # char 1 (曰) followed by ：
+        # char 2 (学) followed by ：
+        result = build_punctuation_map("子，曰：学：")
+        assert result == {0: "，", 1: "：", 2: "："}
+
+    def test_leading_punctuation_keyed_at_minus_one(self):
+        # The function explicitly uses key -1 for sentence-leading
+        # punctuation (per docstring).
+        result = build_punctuation_map("「学而")
+        assert result.get(-1) == "「"
+
+    def test_consecutive_punct_concatenated(self):
+        # When several punct marks follow the same char, they're collected
+        # into one string at that index.
+        result = build_punctuation_map("学。」")
+        assert result.get(0) == "。」"
+
+
+class TestSplitIntoSentences:
+    def test_period_terminator_kept_with_sentence(self):
+        result = split_into_sentences("学而时习之。有朋自远方来。")
+        assert result == ["学而时习之。", "有朋自远方来。"]
+
+    def test_question_and_exclam_terminators(self):
+        result = split_into_sentences("不亦说乎？不亦乐乎！")
+        assert result == ["不亦说乎？", "不亦乐乎！"]
+
+    def test_trailing_text_without_terminator_preserved(self):
+        # The remainder after the last terminator must NOT be dropped.
+        result = split_into_sentences("学而时习之。不亦说乎")
+        assert result == ["学而时习之。", "不亦说乎"]
+
+    def test_empty_input_yields_empty_list(self):
+        assert split_into_sentences("") == []

--- a/backend/tests/services/test_text_compare.py
+++ b/backend/tests/services/test_text_compare.py
@@ -1,0 +1,71 @@
+"""Unit tests for app.services.text_compare.TextComparisonService."""
+from __future__ import annotations
+
+from app.services.text_compare import DiffType, TextComparisonService
+
+
+class TestCompareTexts:
+    def test_identical_texts_have_similarity_1_and_only_equal_diffs(self):
+        svc = TextComparisonService()
+        result = svc.compare_texts("学而时习之", "学而时习之")
+        assert result["similarity"] == 1.0
+        assert all(d.get("type") == DiffType.EQUAL for d in result["differences"])
+
+    def test_completely_different_texts_score_low(self):
+        svc = TextComparisonService()
+        # Disjoint Chinese chars; similarity should be low. Don't pin
+        # to 0.0 — the implementation uses SequenceMatcher heuristics.
+        result = svc.compare_texts("学而时习之", "甲乙丙丁戊")
+        assert result["similarity"] <= 0.2
+
+    def test_layout_differences_dont_count(self):
+        # Per the docstring of compare_texts: line-break differences
+        # between editions (高丽版 20-char lines vs. 福州版 40-char lines)
+        # must NOT register as content differences. Same content, different
+        # newlines → similarity 1.
+        svc = TextComparisonService()
+        with_breaks = "学而时习之\n不亦说乎"
+        without_breaks = "学而时习之不亦说乎"
+        result = svc.compare_texts(with_breaks, without_breaks)
+        assert result["similarity"] == 1.0
+
+    def test_response_shape_is_stable(self):
+        svc = TextComparisonService()
+        result = svc.compare_texts("a", "a", "ed1", "ed2")
+        # Public callers (UI + export) rely on these keys being present.
+        assert set(result.keys()) >= {
+            "version1_name",
+            "version2_name",
+            "differences",
+            "statistics",
+            "similarity",
+        }
+        assert result["version1_name"] == "ed1"
+        assert result["version2_name"] == "ed2"
+
+
+class TestNormalizeTextForComparison:
+    def test_strips_newlines(self):
+        svc = TextComparisonService()
+        # The function exists specifically to make line-break differences
+        # invisible to the diff layer.
+        assert "\n" not in svc.normalize_text_for_comparison("a\nb\nc")
+
+
+class TestCheckPureTextConsistency:
+    def test_same_pure_text_with_diff_punctuation_is_consistent(self):
+        svc = TextComparisonService()
+        consistent, _, _ = svc.check_pure_text_consistency(
+            "学而时习之，不亦说乎",
+            "学而时习之。不亦说乎",
+        )
+        # Pure text (sans punctuation) is identical → True.
+        assert consistent is True
+
+    def test_different_pure_text_is_not_consistent(self):
+        svc = TextComparisonService()
+        consistent, _, _ = svc.check_pure_text_consistency(
+            "学而时习之",
+            "学而时习也",  # 之 → 也
+        )
+        assert consistent is False


### PR DESCRIPTION
## Summary
Builds on the 27-case algorithm baseline from #60. Adds three test files covering modules the UI hits on every "two-edition collation" request.

## Coverage by file

### \`test_punctuation_text_utils.py\` — 12
- \`normalize_for_comparison\`: newline collapse, space collapse, outer-strip, empty input
- \`build_punctuation_map\`: empty map for punct-free input, per-char trailing punct, **key=-1 for sentence-leading punct** (documented invariant), consecutive marks concatenated at one index
- \`split_into_sentences\`: terminator-kept-with-sentence, ?/! terminators, trailing-no-terminator preserved, empty input

### \`test_punctuation_diff_extractor.py\` — 16
- \`get_diff_type\`: all 6 branches (empty1, empty2, replacement, prefix-add, prefix-delete, partial-overlap-replacement)
- \`get_punctuation_category\` / \`get_punctuation_name\`: known marks routed correctly, unknowns fall back
- \`extract_punctuation_differences\`: identical → empty, single swap → 1 diff

### \`test_text_compare.py\` — 7
- \`compare_texts\`: identical similarity 1.0; disjoint low; **layout-only diffs (line-break differences) must NOT count** — the explicit "高丽版每行20字 vs 福州版每行40字" case the docstring calls out; response shape stable
- \`normalize_text_for_comparison\`: strips newlines
- \`check_pure_text_consistency\`: punctuation-only → True; text diff → False

## Total
Backend services suite: **27 → 62 cases**.

## Test plan
- [x] All 62 pass locally (\`pytest tests/services/ -q\`)
- [ ] CI \`Backend smoke tests\` job picks them up

🤖 Generated with [Claude Code](https://claude.com/claude-code)