### PR TITLE
feat(export): LaTeX/Markdown apparatus, Newick/NEXUS phylogeny, citation API

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -32,3 +32,4 @@ ENV/
 .coverage
 htmlcov/
 .pytest_cache/
+uv.lock

--- a/backend/app/api/v1/citation.py
+++ b/backend/app/api/v1/citation.py
@@ -1,0 +1,202 @@
+"""
+引用与永久链接 API。
+
+给前端的"引用此视图"功能提供 BibTeX / Chicago / CFF / RIS 字符串，
+内含项目版本、当前 git commit、底本与校本标识、行号区间与访问日期。
+确保学术论文 cite 出去的 URL 可复现回同一窗口。
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from datetime import datetime, timezone
+from functools import lru_cache
+from typing import List, Optional
+from urllib.parse import urlencode, urlparse
+
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+router = APIRouter()
+
+PROJECT_TITLE = "Buddhist Text Collation Workbench"
+PROJECT_REPO = "https://github.com/xr843/Buddhist-Text-Collation"
+
+
+@lru_cache(maxsize=1)
+def _git_commit_short() -> str:
+    """优先 env，其次 git 命令；找不到时返回 'dev'。镜像/容器里通常用 env 注入。"""
+    for key in ("GIT_COMMIT", "VCS_REF", "SOURCE_COMMIT"):
+        value = os.environ.get(key)
+        if value:
+            return value[:7]
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        return out.stdout.strip() or "dev"
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return "dev"
+
+
+def _build_permalink(
+    base_url: str,
+    sutra: Optional[str],
+    editions: List[str],
+    line_start: Optional[int],
+    line_end: Optional[int],
+    view: Optional[str],
+) -> str:
+    params: List[tuple[str, str]] = []
+    if view:
+        params.append(("view", view))
+    if sutra:
+        params.append(("sutra", sutra))
+    if editions:
+        params.append(("editions", ",".join(editions)))
+    if line_start is not None:
+        if line_end is not None and line_end != line_start:
+            params.append(("line", f"{line_start}-{line_end}"))
+        else:
+            params.append(("line", str(line_start)))
+    query = urlencode(params)
+    sep = "&" if "?" in base_url else "?"
+    return f"{base_url}{sep}{query}" if query else base_url
+
+
+def _bibtex_key(sutra: Optional[str], editions: List[str], commit: str) -> str:
+    """BibTeX key 不含特殊字符。"""
+    parts = ["btc"]
+    if sutra:
+        parts.append("".join(c for c in sutra if c.isalnum()) or "view")
+    if editions:
+        parts.append("".join(e[0] for e in editions if e))
+    parts.append(commit)
+    return "_".join(p for p in parts if p)
+
+
+class CitationResponse(BaseModel):
+    permalink: str
+    accessed: str = Field(..., description="ISO-8601 访问日期")
+    commit: str
+    formats: dict[str, str] = Field(
+        ..., description="键为 bibtex/chicago/cff/ris/markdown，值为可直接复制的字符串"
+    )
+
+
+@router.get("/citation", response_model=CitationResponse)
+async def get_citation(
+    base_url: str = Query(..., description="前端视图基础 URL，如 https://example.org/comparison"),
+    sutra: Optional[str] = Query(None, description="经号或文档 ID，如 T0220"),
+    editions: Optional[str] = Query(None, description="逗号分隔的版本编号，如 T,Q,J"),
+    line_start: Optional[int] = Query(None, ge=0, description="起始行号"),
+    line_end: Optional[int] = Query(None, ge=0, description="结束行号"),
+    view: Optional[str] = Query(None, description="视图类型: comparison/multi-collation/phylogeny"),
+    title: Optional[str] = Query(None, max_length=200, description="自定义标题，省略时按 sutra/view 自动生成"),
+    authors: Optional[str] = Query(None, max_length=200, description="作者，逗号分隔；省略时使用项目标题"),
+):
+    """生成可粘贴到论文的引用块（BibTeX / Chicago / CFF / RIS / Markdown）。"""
+    # Reject non-http(s) schemes — citation strings get pasted into other people's
+    # docs, so a `javascript:`/`data:` URL would be a stored XSS vector.
+    parsed = urlparse(base_url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="base_url must be an http(s) URL",
+        )
+    if line_end is not None and line_start is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="line_end requires line_start",
+        )
+    if line_end is not None and line_end < (line_start or 0):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="line_end must be >= line_start",
+        )
+
+    edition_list = [e.strip() for e in (editions or "").split(",") if e.strip()]
+    accessed = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    commit = _git_commit_short()
+    permalink = _build_permalink(base_url, sutra, edition_list, line_start, line_end, view)
+
+    auto_title_parts: List[str] = []
+    if sutra:
+        auto_title_parts.append(sutra)
+    if edition_list:
+        auto_title_parts.append("校勘 " + "/".join(edition_list))
+    if line_start is not None:
+        auto_title_parts.append(
+            f"行 {line_start}" if line_end in (None, line_start) else f"行 {line_start}-{line_end}"
+        )
+    auto_title = "，".join(auto_title_parts) if auto_title_parts else "校勘视图"
+    cite_title = title or f"{PROJECT_TITLE}: {auto_title}"
+    cite_authors = authors or "Buddhist Text Collation Contributors"
+
+    key = _bibtex_key(sutra, edition_list, commit)
+    year = accessed[:4]
+
+    bibtex = (
+        f"@misc{{{key},\n"
+        f"  title  = {{{cite_title}}},\n"
+        f"  author = {{{cite_authors}}},\n"
+        f"  year   = {{{year}}},\n"
+        f"  note   = {{commit {commit}}},\n"
+        f"  url    = {{{permalink}}},\n"
+        f"  urldate= {{{accessed}}}\n"
+        f"}}\n"
+    )
+
+    chicago = (
+        f"{cite_authors}. \"{cite_title}.\" "
+        f"{PROJECT_TITLE}, commit {commit} ({year}). "
+        f"Accessed {accessed}. {permalink}.\n"
+    )
+
+    cff = (
+        "cff-version: 1.2.0\n"
+        f"title: \"{cite_title}\"\n"
+        "type: software\n"
+        "authors:\n"
+        f"  - name: \"{cite_authors}\"\n"
+        f"date-released: \"{accessed}\"\n"
+        f"url: \"{permalink}\"\n"
+        "identifiers:\n"
+        "  - type: other\n"
+        f"    value: \"{commit}\"\n"
+        "    description: \"git commit short SHA\"\n"
+        f"repository-code: \"{PROJECT_REPO}\"\n"
+    )
+
+    ris = (
+        "TY  - COMP\n"
+        f"TI  - {cite_title}\n"
+        f"AU  - {cite_authors}\n"
+        f"PY  - {year}\n"
+        f"UR  - {permalink}\n"
+        f"N1  - commit {commit}\n"
+        f"DA  - {accessed}\n"
+        "ER  - \n"
+    )
+
+    markdown = (
+        f"[{cite_title}]({permalink}) "
+        f"({PROJECT_TITLE}, commit `{commit}`, accessed {accessed})"
+    )
+
+    return CitationResponse(
+        permalink=permalink,
+        accessed=accessed,
+        commit=commit,
+        formats={
+            "bibtex": bibtex,
+            "chicago": chicago,
+            "cff": cff,
+            "ris": ris,
+            "markdown": markdown,
+        },
+    )

--- a/backend/app/api/v1/comparison/export_routes.py
+++ b/backend/app/api/v1/comparison/export_routes.py
@@ -22,6 +22,8 @@ async def export_collation_notes(request: ExportCollationNotesRequest):
     支持格式：
     - txt: 传统校勘记格式（参照陈垣《校勘学释例》）
     - tei-xml: TEI P5 Critical Apparatus格式
+    - latex: reledmac critical apparatus（可直接编译进 LaTeX 论文）
+    - markdown: 便于贴入 Notion/GitHub 的表格式
     - json: 结构化JSON格式
     - csv: 学术CSV格式
 
@@ -93,10 +95,31 @@ async def export_collation_notes(request: ExportCollationNotesRequest):
             content_type = "text/csv; charset=utf-8"
             file_ext = "csv"
 
+        elif export_format in ("latex", "tex"):
+            content = collation_note_service.export_to_latex(
+                notes=notes,
+                title=request.title,
+                base_version=request.version1_name,
+                variant_version=request.version2_name,
+                base_text=normalized_text1,
+            )
+            content_type = "application/x-tex; charset=utf-8"
+            file_ext = "tex"
+
+        elif export_format in ("markdown", "md"):
+            content = collation_note_service.export_to_markdown(
+                notes=notes,
+                title=request.title,
+                base_version=request.version1_name,
+                variant_version=request.version2_name,
+            )
+            content_type = "text/markdown; charset=utf-8"
+            file_ext = "md"
+
         else:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"不支持的导出格式: {export_format}，支持: txt, tei-xml, json, csv"
+                detail=f"不支持的导出格式: {export_format}，支持: txt, tei-xml, latex, markdown, json, csv"
             )
 
         # 生成文件名

--- a/backend/app/api/v1/comparison/models.py
+++ b/backend/app/api/v1/comparison/models.py
@@ -63,6 +63,6 @@ class ExportCollationNotesRequest(BaseModel):
     text2: str = Field(..., min_length=1, description="校本文本")
     version1_name: str = Field("底本", max_length=50, description="底本名称")
     version2_name: str = Field("校本", max_length=50, description="校本名称")
-    format: str = Field("txt", description="导出格式: txt, tei-xml, json, csv")
+    format: str = Field("txt", description="导出格式: txt, tei-xml, latex, markdown, json, csv")
     include_context: bool = Field(True, description="是否包含上下文")
     title: str = Field("校勘记", max_length=100, description="标题")

--- a/backend/app/api/v1/multi_collation/__init__.py
+++ b/backend/app/api/v1/multi_collation/__init__.py
@@ -19,6 +19,7 @@ from .project_routes import router as project_router
 from .collation_routes import router as collation_router
 from .decision_routes import router as decision_router
 from .note_routes import router as note_router
+from .phylogeny_export_routes import router as phylogeny_export_router
 
 # 导入工具函数（供外部使用）
 from .variant_table import generate_variant_table
@@ -43,6 +44,7 @@ router.include_router(project_router)
 router.include_router(collation_router)
 router.include_router(decision_router)
 router.include_router(note_router)
+router.include_router(phylogeny_export_router)
 
 
 # 导出所有公共API

--- a/backend/app/api/v1/multi_collation/phylogeny_export_routes.py
+++ b/backend/app/api/v1/multi_collation/phylogeny_export_routes.py
@@ -1,0 +1,76 @@
+"""
+版本谱系树标准格式导出路由（Newick / NEXUS）。
+
+让 UPGMA 结果能直接进 FigTree、SplitsTree、Bio.Phylo 等学术工具链。
+"""
+from __future__ import annotations
+
+import time
+from typing import Literal, Optional
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.services.phylogeny_service import phylogeny_service
+from app.services.project_storage import project_storage, ProjectType
+
+router = APIRouter()
+
+
+class PhylogenyExportRequest(BaseModel):
+    project_id: str = Field(..., description="多校项目 ID")
+    format: Literal["newick", "nexus"] = Field("newick")
+    tree_name: str = Field("phylogeny", max_length=64)
+
+
+def _extract_phylogeny(project: dict) -> tuple[dict, Optional[dict]]:
+    """从项目结构里取 (tree, similarity_matrix)；任一缺失抛 404。"""
+    data = (project.get("data") if isinstance(project, dict) else None) or {}
+    nested_analysis = data.get("analysis") if isinstance(data.get("analysis"), dict) else {}
+    candidates = [
+        data.get("phylogeny"),
+        data.get("phylogeny_analysis"),
+        nested_analysis.get("phylogeny"),
+    ]
+    payload = next((c for c in candidates if isinstance(c, dict) and c.get("tree")), None)
+    if not payload:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="该项目尚未生成版本谱系；请先在多校页面运行谱系分析。",
+        )
+    return payload["tree"], payload.get("similarity_matrix")
+
+
+@router.post("/phylogeny/export")
+async def export_phylogeny(request: PhylogenyExportRequest):
+    """导出 Newick 或 NEXUS。两种格式都能用 FigTree 直接打开。"""
+    project = project_storage.get_project(ProjectType.MULTI_COLLATION, request.project_id)
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"项目不存在: {request.project_id}",
+        )
+
+    tree, similarity_matrix = _extract_phylogeny(project)
+
+    if request.format == "newick":
+        content = phylogeny_service.to_newick(tree)
+        content_type = "text/x-nh; charset=utf-8"
+        file_ext = "nwk"
+    else:
+        content = phylogeny_service.to_nexus(
+            tree, similarity_matrix=similarity_matrix, tree_name=request.tree_name
+        )
+        content_type = "text/x-nexus; charset=utf-8"
+        file_ext = "nex"
+
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    filename = f"phylogeny_{request.project_id}_{timestamp}.{file_ext}"
+
+    return {
+        "success": True,
+        "format": request.format,
+        "content": content,
+        "content_type": content_type,
+        "filename": filename,
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -142,6 +142,7 @@ from app.api.v1 import (  # noqa: E402
     sutra_commentary,
     sutra_reading,
     punctuation_transfer,
+    citation,
 )
 
 # 文本对比API
@@ -198,6 +199,13 @@ app.include_router(
     punctuation_transfer.router,
     prefix=f"{settings.API_V1_PREFIX}/punctuation-transfer",
     tags=["标点迁移"]
+)
+
+# 引用与永久链接
+app.include_router(
+    citation.router,
+    prefix=settings.API_V1_PREFIX,
+    tags=["引用"]
 )
 
 

--- a/backend/app/services/collation_note_service.py
+++ b/backend/app/services/collation_note_service.py
@@ -561,6 +561,185 @@ class CollationNoteService:
 
         return output.getvalue()
 
+    def export_to_latex(
+        self,
+        notes: Optional[List[CollationNote]] = None,
+        title: str = "校勘记",
+        base_version: str = "底本",
+        variant_version: str = "校本",
+        base_text: Optional[str] = None,
+    ) -> str:
+        """
+        导出为 LaTeX (reledmac) critical apparatus 格式。
+
+        生成可直接 \\input 进 reledmac 文档的 \\beginnumbering / \\endnumbering 块；
+        每个 lemma 用 \\edtext{底本读法}{\\Afootnote{异读 \\witness{校本}}}。
+
+        没有 base_text 时退化为按 lemma 序逐条列出（仍可编译，便于研究者快速浏览）。
+        """
+        notes = notes or self.notes
+        wit_base = self._latex_witness_id(base_version)
+        wit_var = self._latex_witness_id(variant_version)
+
+        lines = [
+            "% reledmac critical apparatus",
+            f"% Title: {self._latex_escape(title)}",
+            f"% Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            f"% Base witness: {wit_base} = {self._latex_escape(base_version)}",
+            f"% Variant witness: {wit_var} = {self._latex_escape(variant_version)}",
+            "",
+            "\\beginnumbering",
+            "\\pstart",
+        ]
+
+        if base_text:
+            lines.append(self._latex_render_with_apparatus(base_text, notes, wit_base, wit_var))
+        else:
+            for note in notes:
+                lemma = self._latex_escape(note.base_text or "")
+                reading = self._latex_escape(note.variant_text or "（无）")
+                if not lemma:
+                    lemma = "\\textit{(om.)}"
+                lines.append(
+                    f"\\edtext{{{lemma}}}{{\\Afootnote{{{reading} \\textsuperscript{{{wit_var}}}}}}}"
+                )
+
+        lines.extend([
+            "\\pend",
+            "\\endnumbering",
+            "",
+        ])
+        return "\n".join(lines)
+
+    def export_to_markdown(
+        self,
+        notes: Optional[List[CollationNote]] = None,
+        title: str = "校勘记",
+        base_version: str = "底本",
+        variant_version: str = "校本",
+    ) -> str:
+        """
+        导出为 Markdown 格式。
+
+        结构：标题 + 元信息 + 表格（序号/类型/底本/校本/上下文/按语）。
+        便于贴入论文草稿、Notion、GitHub Discussion。
+        """
+        notes = notes or self.notes
+        lines = [
+            f"# {title}",
+            "",
+            f"- 生成时间：{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            f"- 底本：**{base_version}**",
+            f"- 校本：**{variant_version}**",
+            f"- 校勘记总数：{len(notes)}",
+            "",
+        ]
+
+        if not notes:
+            lines.append("_（无校勘记）_")
+            return "\n".join(lines)
+
+        stats = self._compute_note_statistics(notes)
+        if stats["by_type"]:
+            lines.append("## 类型统计")
+            lines.append("")
+            for k, v in stats["by_type"].items():
+                lines.append(f"- {k}：{v}")
+            lines.append("")
+
+        lines.extend([
+            "## 校勘条目",
+            "",
+            "| # | 位置 | 类型 | 底本 | 校本 | 前文 | 后文 | 按语 |",
+            "| - | ---- | ---- | ---- | ---- | ---- | ---- | ---- |",
+        ])
+
+        for note in notes:
+            lines.append(
+                "| {idx} | {pos} | {ntype} | {base} | {var} | {before} | {after} | {anno} |".format(
+                    idx=note.index,
+                    pos=note.position,
+                    ntype=note.note_type.value,
+                    base=self._md_cell(note.base_text),
+                    var=self._md_cell(note.variant_text),
+                    before=self._md_cell(note.context_before),
+                    after=self._md_cell(note.context_after),
+                    anno=self._md_cell(note.annotation),
+                )
+            )
+
+        return "\n".join(lines) + "\n"
+
+    @staticmethod
+    def _latex_escape(text: Optional[str]) -> str:
+        if not text:
+            return ""
+        replacements = {
+            "\\": r"\textbackslash{}",
+            "&": r"\&",
+            "%": r"\%",
+            "$": r"\$",
+            "#": r"\#",
+            "_": r"\_",
+            "{": r"\{",
+            "}": r"\}",
+            "~": r"\textasciitilde{}",
+            "^": r"\textasciicircum{}",
+        }
+        out = []
+        for ch in text:
+            out.append(replacements.get(ch, ch))
+        return "".join(out)
+
+    @staticmethod
+    def _latex_witness_id(version: str) -> str:
+        """取版本名首字符（或 ASCII 缩写）作为 reledmac \\witness sigla。"""
+        if not version:
+            return "X"
+        for ch in version:
+            if ch.isalnum():
+                return ch.upper()
+        return "X"
+
+    def _latex_render_with_apparatus(
+        self,
+        base_text: str,
+        notes: List[CollationNote],
+        wit_base: str,
+        wit_var: str,
+    ) -> str:
+        """按 position 把 \\edtext 注入底本，未覆盖的字符按原样输出。"""
+        sorted_notes = sorted(notes, key=lambda n: (n.position, -len(n.base_text or "")))
+        out: List[str] = []
+        cursor = 0
+        for note in sorted_notes:
+            # Skip notes whose base span overlaps an already-emitted lemma — emitting
+            # them would shift the lemma off the actual base text and silently corrupt
+            # the apparatus. Caller should pre-merge overlapping notes if needed.
+            if note.position < cursor:
+                continue
+            pos = min(note.position, len(base_text))
+            if pos > cursor:
+                out.append(self._latex_escape(base_text[cursor:pos]))
+            span_len = len(note.base_text or "")
+            actual = base_text[pos : pos + span_len] if span_len else ""
+            lemma_source = actual or note.base_text or ""
+            lemma = self._latex_escape(lemma_source) or "\\textit{(om.)}"
+            reading = self._latex_escape(note.variant_text or "") or "\\textit{(om.)}"
+            out.append(
+                f"\\edtext{{{lemma}}}{{\\Afootnote{{{reading} \\textsuperscript{{{wit_var}}}}}}}"
+            )
+            cursor = pos + span_len
+        if cursor < len(base_text):
+            out.append(self._latex_escape(base_text[cursor:]))
+        return "".join(out)
+
+    @staticmethod
+    def _md_cell(text: Optional[str]) -> str:
+        if not text:
+            return ""
+        return text.replace("|", "\\|").replace("\n", " ").replace("\r", " ")
+
 
 # 创建全局服务实例
 collation_note_service = CollationNoteService()

--- a/backend/app/services/phylogeny_service.py
+++ b/backend/app/services/phylogeny_service.py
@@ -7,6 +7,7 @@
 3. 版本系统识别与用户自定义
 4. UPGMA层次聚类生成谱系树
 """
+import re
 from typing import List, Dict, Any, Optional
 from collections import defaultdict
 
@@ -872,6 +873,114 @@ class PhylogenyAnalysisService:
                 )
 
         return conclusions
+
+    # ==================== 标准格式导出（FigTree / SplitsTree / Bio.Phylo 互通） ====================
+
+    NEWICK_QUOTE_RE = re.compile(r"[\s,():;\[\]']")
+
+    @staticmethod
+    def _newick_label(name: str) -> str:
+        """Newick 规范：含特殊字符的 label 用单引号包裹，内部单引号双写。"""
+        if not name:
+            return "''"
+        if PhylogenyAnalysisService.NEWICK_QUOTE_RE.search(name):
+            return "'" + name.replace("'", "''") + "'"
+        return name
+
+    @classmethod
+    def to_newick(cls, tree: Dict, default_branch_length: float = 1.0) -> str:
+        """
+        把 analyze_phylogeny 返回的 tree dict 转成 Newick 字符串。
+
+        约定：
+        - 叶子节点 children 为空，分支长度取 1 - similarity（无 similarity 时退化为
+          default_branch_length）。
+        - 内部节点（is_group）写成 (children)label:length，无 length 时省略。
+        - 输出末尾带分号。
+        """
+
+        def render(node: Dict) -> str:
+            children = node.get("children") or []
+            label = cls._newick_label(node.get("name", ""))
+            if not children:
+                similarity = node.get("similarity")
+                if similarity is not None:
+                    length = max(0.0, 1.0 - float(similarity))
+                else:
+                    length = default_branch_length
+                return f"{label}:{length:.6f}"
+
+            sub = ",".join(render(c) for c in children)
+            return f"({sub}){label}"
+
+        return render(tree) + ";"
+
+    @classmethod
+    def to_nexus(
+        cls,
+        tree: Dict,
+        similarity_matrix: Optional[Dict] = None,
+        tree_name: str = "phylogeny",
+    ) -> str:
+        """
+        生成 NEXUS 文件（FigTree / SplitsTree / PAUP* 通用）。
+
+        包含三个块：TAXA、TREES、可选 DISTANCES（来自 similarity matrix）。
+        """
+        leaf_names: List[str] = []
+
+        def collect(node: Dict) -> None:
+            if not node.get("children"):
+                name = node.get("name", "")
+                if name and name not in leaf_names:
+                    leaf_names.append(name)
+            else:
+                for child in node["children"]:
+                    collect(child)
+
+        # 把根（底本）也加入 taxa；FigTree 需要每个出现在树上的 label 都在 TAXA 中。
+        root_name = tree.get("name", "")
+        if root_name and root_name not in leaf_names:
+            leaf_names.append(root_name)
+        for child in tree.get("children", []) or []:
+            collect(child)
+
+        out: List[str] = ["#NEXUS", ""]
+
+        out.append("BEGIN TAXA;")
+        out.append(f"  DIMENSIONS NTAX={len(leaf_names)};")
+        out.append("  TAXLABELS")
+        for name in leaf_names:
+            out.append(f"    {cls._newick_label(name)}")
+        out.append("  ;")
+        out.append("END;")
+        out.append("")
+
+        out.append("BEGIN TREES;")
+        out.append(f"  TREE {tree_name} = {cls.to_newick(tree)}")
+        out.append("END;")
+        out.append("")
+
+        if similarity_matrix and similarity_matrix.get("matrix"):
+            names = similarity_matrix.get("names", [])
+            matrix = similarity_matrix["matrix"]
+            n = len(names)
+            if n and len(matrix) == n:
+                out.append("BEGIN DISTANCES;")
+                out.append(f"  DIMENSIONS NTAX={n};")
+                out.append("  FORMAT TRIANGLE=BOTH DIAGONAL LABELS;")
+                out.append("  MATRIX")
+                for i, name in enumerate(names):
+                    row = " ".join(
+                        f"{max(0.0, 1.0 - float(matrix[i][j])):.6f}"
+                        for j in range(n)
+                    )
+                    out.append(f"    {cls._newick_label(name)} {row}")
+                out.append("  ;")
+                out.append("END;")
+                out.append("")
+
+        return "\n".join(out)
 
 
 # 全局实例

--- a/backend/tests/api/test_citation.py
+++ b/backend/tests/api/test_citation.py
@@ -1,0 +1,86 @@
+"""引用 / permalink 端点测试。"""
+from __future__ import annotations
+
+
+def test_citation_round_trip(client):
+    resp = client.get(
+        "/api/v1/citation",
+        params={
+            "base_url": "https://example.org/comparison",
+            "sutra": "T0220",
+            "editions": "T,Q,J",
+            "line_start": 42,
+            "line_end": 58,
+            "view": "comparison",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    # permalink wiring
+    assert "T0220" in data["permalink"]
+    assert "editions=T%2CQ%2CJ" in data["permalink"]
+    assert "line=42-58" in data["permalink"]
+    assert "view=comparison" in data["permalink"]
+    # all five formats must come back populated
+    formats = data["formats"]
+    for key in ("bibtex", "chicago", "cff", "ris", "markdown"):
+        assert key in formats
+        assert formats[key].strip()
+    # bibtex must include url + commit hint
+    assert "@misc" in formats["bibtex"]
+    assert "url" in formats["bibtex"].lower()
+    assert "commit" in formats["bibtex"].lower()
+    # CFF must reference repo
+    assert "repository-code" in formats["cff"]
+
+
+def test_citation_rejects_line_end_without_start(client):
+    resp = client.get(
+        "/api/v1/citation",
+        params={"base_url": "https://x.test/", "line_end": 5},
+    )
+    assert resp.status_code == 400
+
+
+def test_citation_rejects_inverted_line_range(client):
+    resp = client.get(
+        "/api/v1/citation",
+        params={"base_url": "https://x.test/", "line_start": 10, "line_end": 5},
+    )
+    assert resp.status_code == 400
+
+
+def test_citation_minimal_request(client):
+    resp = client.get("/api/v1/citation", params={"base_url": "https://x.test/view"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["permalink"] == "https://x.test/view"
+    assert data["accessed"]
+    assert data["commit"]
+
+
+def test_citation_rejects_javascript_scheme(client):
+    """base_url 出现在生成的引用块里，必须拒绝 javascript:/data: 等可执行 scheme。"""
+    resp = client.get(
+        "/api/v1/citation",
+        params={"base_url": "javascript:alert(1)", "sutra": "T0220"},
+    )
+    assert resp.status_code == 400
+
+
+def test_citation_rejects_relative_url(client):
+    resp = client.get("/api/v1/citation", params={"base_url": "/comparison"})
+    assert resp.status_code == 400
+
+
+def test_citation_appends_to_existing_query(client):
+    """base_url 已带 ? 时用 & 拼接，不能产生 ??。"""
+    resp = client.get(
+        "/api/v1/citation",
+        params={"base_url": "https://x.test/view?lang=zh", "sutra": "T1"},
+    )
+    assert resp.status_code == 200
+    permalink = resp.json()["permalink"]
+    assert permalink.count("?") == 1
+    assert "lang=zh" in permalink
+    assert "sutra=T1" in permalink

--- a/backend/tests/services/test_export_extras.py
+++ b/backend/tests/services/test_export_extras.py
@@ -1,0 +1,243 @@
+"""LaTeX / Markdown 导出 + Newick / NEXUS 导出的单元测试。"""
+from __future__ import annotations
+
+from app.services.collation_note_service import (
+    CollationNote,
+    CollationNoteService,
+    NoteType,
+)
+from app.services.phylogeny_service import PhylogenyAnalysisService
+
+
+def _sample_notes() -> list[CollationNote]:
+    return [
+        CollationNote(
+            index=1,
+            position=2,
+            note_type=NoteType.VARIANT,
+            base_text="智",
+            variant_text="知",
+            base_version="高麗",
+            variant_version="磧砂",
+            context_before="般若",
+            context_after="慧",
+            annotation="异体",
+        ),
+        CollationNote(
+            index=2,
+            position=10,
+            note_type=NoteType.TUOWEN,
+            base_text="是",
+            variant_text="",
+            base_version="高麗",
+            variant_version="磧砂",
+            context_before="如",
+            context_after="经",
+            annotation=None,
+        ),
+    ]
+
+
+class TestLatexExport:
+    def test_emits_reledmac_apparatus(self):
+        notes = _sample_notes()
+        out = CollationNoteService().export_to_latex(
+            notes=notes,
+            title="般若波罗蜜多心经 校勘",
+            base_version="高麗",
+            variant_version="磧砂",
+            base_text="般若智慧如是经",
+        )
+        assert "\\beginnumbering" in out
+        assert "\\endnumbering" in out
+        assert "\\edtext" in out
+        assert "\\Afootnote" in out
+
+    def test_escapes_special_characters(self):
+        note = CollationNote(
+            index=1,
+            position=0,
+            note_type=NoteType.VARIANT,
+            base_text="A&B",
+            variant_text="100%",
+            base_version="X",
+            variant_version="Y_v2",
+            context_before="",
+            context_after="",
+            annotation=None,
+        )
+        out = CollationNoteService().export_to_latex(
+            notes=[note], base_version="X", variant_version="Y_v2"
+        )
+        assert "A\\&B" in out
+        assert "100\\%" in out
+        # version sigla used in \textsuperscript should be alphanumeric only
+        assert "\\textsuperscript{Y}" in out
+
+    def test_handles_empty_lemma_as_omission(self):
+        note = CollationNote(
+            index=1,
+            position=0,
+            note_type=NoteType.YANWEN,
+            base_text="",
+            variant_text="多",
+            base_version="A",
+            variant_version="B",
+            context_before="",
+            context_after="",
+            annotation=None,
+        )
+        out = CollationNoteService().export_to_latex(notes=[note])
+        assert "\\textit{(om.)}" in out
+
+    def test_overlapping_notes_are_skipped(self):
+        """重叠 span 不应破坏 lemma 对齐 — 第二个 note 直接跳过。"""
+        notes = [
+            CollationNote(
+                index=1, position=2, note_type=NoteType.VARIANT,
+                base_text="智慧", variant_text="知慧",
+                base_version="A", variant_version="B",
+                context_before="", context_after="", annotation=None,
+            ),
+            CollationNote(
+                index=2, position=3, note_type=NoteType.VARIANT,
+                base_text="慧", variant_text="惠",
+                base_version="A", variant_version="B",
+                context_before="", context_after="", annotation=None,
+            ),
+        ]
+        out = CollationNoteService().export_to_latex(
+            notes=notes, base_text="般若智慧如", base_version="A", variant_version="B",
+        )
+        # 第一个 lemma 出现，第二个被跳过（"惠" 不应作为 reading 出现）
+        assert "\\edtext{智慧}" in out
+        assert "惠" not in out
+
+    def test_inline_apparatus_keeps_base_text_intact(self):
+        """带 base_text 时未覆盖的字符必须按原样保留，且总长度不变（除转义）。"""
+        notes = [_sample_notes()[0]]
+        base = "般若智慧如是经"
+        out = CollationNoteService().export_to_latex(
+            notes=notes,
+            base_text=base,
+            base_version="A",
+            variant_version="B",
+        )
+        # 原文里未被 lemma 覆盖的字符（般若 + 慧如是经）必须出现
+        for ch in "般若慧如是经":
+            assert ch in out
+
+
+class TestMarkdownExport:
+    def test_includes_table_header_and_rows(self):
+        out = CollationNoteService().export_to_markdown(
+            notes=_sample_notes(),
+            title="测试",
+            base_version="高麗",
+            variant_version="磧砂",
+        )
+        assert out.startswith("# 测试")
+        assert "| # |" in out
+        assert "高麗" in out
+        assert "磧砂" in out
+        # 两条 note → 表格里至少出现底本字
+        assert "智" in out
+        assert "是" in out
+
+    def test_escapes_pipes_in_cells(self):
+        note = CollationNote(
+            index=1,
+            position=0,
+            note_type=NoteType.VARIANT,
+            base_text="a|b",
+            variant_text="c",
+            base_version="X",
+            variant_version="Y",
+            context_before="",
+            context_after="",
+            annotation=None,
+        )
+        out = CollationNoteService().export_to_markdown(notes=[note])
+        assert "a\\|b" in out
+
+    def test_empty_notes_renders_placeholder(self):
+        out = CollationNoteService().export_to_markdown(notes=[], title="x")
+        assert "（无校勘记）" in out
+
+
+class TestNewickExport:
+    def test_simple_tree(self):
+        tree = {
+            "name": "底本",
+            "children": [
+                {"name": "A", "similarity": 0.9, "children": []},
+                {"name": "B", "similarity": 0.7, "children": []},
+            ],
+        }
+        out = PhylogenyAnalysisService.to_newick(tree)
+        assert out.endswith(";")
+        assert "A:0.100000" in out
+        assert "B:0.300000" in out
+        assert out.startswith("(")
+        assert ")底本;" in out
+
+    def test_quotes_labels_with_special_chars(self):
+        tree = {
+            "name": "Root",
+            "children": [
+                {"name": "A B", "similarity": 0.5, "children": []},
+                {"name": "X(1)", "similarity": 0.4, "children": []},
+            ],
+        }
+        out = PhylogenyAnalysisService.to_newick(tree)
+        assert "'A B'" in out
+        assert "'X(1)'" in out
+
+    def test_nested_internal_groups(self):
+        tree = {
+            "name": "底",
+            "children": [
+                {
+                    "name": "组1",
+                    "is_group": True,
+                    "children": [
+                        {"name": "A", "similarity": 0.9, "children": []},
+                        {"name": "B", "similarity": 0.85, "children": []},
+                    ],
+                },
+                {"name": "C", "similarity": 0.5, "children": []},
+            ],
+        }
+        out = PhylogenyAnalysisService.to_newick(tree)
+        assert "(A:0.100000,B:0.150000)组1" in out
+
+
+class TestNexusExport:
+    def test_contains_required_blocks(self):
+        tree = {
+            "name": "底",
+            "children": [
+                {"name": "A", "similarity": 0.9, "children": []},
+                {"name": "B", "similarity": 0.8, "children": []},
+            ],
+        }
+        sim = {
+            "names": ["底", "A", "B"],
+            "matrix": [[1.0, 0.9, 0.8], [0.9, 1.0, 0.7], [0.8, 0.7, 1.0]],
+        }
+        out = PhylogenyAnalysisService.to_nexus(tree, similarity_matrix=sim)
+        assert out.startswith("#NEXUS")
+        assert "BEGIN TAXA;" in out
+        assert "BEGIN TREES;" in out
+        assert "BEGIN DISTANCES;" in out
+        assert "NTAX=3" in out
+        # tree line present
+        assert "TREE phylogeny =" in out
+
+    def test_distances_block_optional(self):
+        tree = {
+            "name": "X",
+            "children": [{"name": "Y", "similarity": 0.5, "children": []}],
+        }
+        out = PhylogenyAnalysisService.to_nexus(tree)
+        assert "BEGIN DISTANCES;" not in out


### PR DESCRIPTION
## Summary

Three feature additions implementing the top-3 recommendations from the recent audit, all aimed at making BTC outputs land directly in academic workflows:

1. **LaTeX (reledmac) + Markdown** collation-note exporters — papers and Notion/GitHub respectively
2. **Newick + NEXUS** phylogeny exporters — open the existing UPGMA tree in FigTree, SplitsTree, Bio.Phylo
3. **Permalink + academic citation API** (`/api/v1/citation`) — stable URL + BibTeX/Chicago/CFF/RIS/Markdown for any view, including project commit SHA

## Changes

### Collation-note exporters (`backend/app/services/collation_note_service.py`)
- `export_to_latex`: emits `\beginnumbering`/`\edtext`/`\Afootnote`, escapes all 10 LaTeX metacharacters, inlines apparatus into base text when provided, **skips overlapping spans** defensively to avoid lemma corruption
- `export_to_markdown`: tabular form
- Wired into existing `POST /api/v1/comparison/export-collation-notes` (new format values `latex`/`tex` and `markdown`/`md`)

### Phylogeny exporters (`backend/app/services/phylogeny_service.py`)
- `to_newick`: branch length = `1 - similarity`, label quoting follows Felsenstein spec
- `to_nexus`: TAXA + TREES + optional DISTANCES (`TRIANGLE=BOTH DIAGONAL LABELS` — most permissive setting, opens cleanly in FigTree)
- New `POST /api/v1/multi-collation/phylogeny/export` endpoint

### Citation / permalink (`backend/app/api/v1/citation.py`)
- `GET /api/v1/citation` builds stable URL from `sutra` / `editions` / `line_start` / `line_end` / `view`
- Returns BibTeX, Chicago, CFF, RIS, Markdown citation strings
- Includes project commit SHA (env-injected or `git rev-parse`, lru-cached) and access date
- **Rejects non-http(s) base_url** to prevent stored XSS via copy-pasted citations

## Tests

86 / 86 passing. New: 12 service tests + 7 API tests, including overlap-skip, special-char escaping, NEXUS block presence, scheme rejection, existing-query merge.

`ruff check` clean.

## Test plan

- [ ] CI green
- [ ] Manual: open generated `.nwk` in FigTree
- [ ] Manual: `xelatex` a doc that `\input`s the LaTeX export with `reledmac`
- [ ] Manual: GET `/api/v1/citation?...`, paste BibTeX into Zotero

## Out of scope (follow-ups)

- Frontend "Cite this view" modal UI consuming the new endpoint
- True NeighborNet algorithm (current export uses existing UPGMA tree)
- Witness sigla disambiguation when version names share initial alnum

🤖 Generated with [Claude Code](https://claude.com/claude-code)