### PR TITLE
fix(ocr): split login/recognize hosts + configurable TLS verify for gj.cool

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -46,12 +46,16 @@ MAX_TEXT_LENGTH=50000
 
 # 古籍酷（gj.cool）OCR 配置
 # -------------------------------------------
-# 接入古籍酷古籍 OCR API（图片→文字）。base_url 与 apiid 从古籍酷「账户设置」页获取
-# （apiid 是账户专属标识，不是登录用户名）。三项凭据都填了 OCR tab 才会启用。
+# 接入古籍酷古籍 OCR API（图片→文字）。两段式：登录在中心化的 ocr.gj.cool，
+# 识别在账户专属 worker（见账户「演示」页古籍OCR 的 URL，如 https://ap2.jzd.cool:9043）。
+# apiid 是账户专属标识（账户页「API ID」），不是登录用户名。三项凭据都填了 OCR tab 才会启用。
 OCR_ENABLED=true
-GJCOOL_OCR_BASE_URL=""
+GJCOOL_OCR_BASE_URL=""                       # 识别 worker，如 https://ap2.jzd.cool:9043
+GJCOOL_OCR_LOGIN_BASE_URL="https://ocr.gj.cool"
 GJCOOL_OCR_APIID=""
 GJCOOL_OCR_PASSWORD=""
+# worker 证书若过期/不被信任，临时设 false 关闭 TLS 校验（对方续期后改回 true）
+GJCOOL_OCR_VERIFY_SSL=true
 # 单次 OCR 请求超时（秒）/ 上传图片大小上限（字节，默认 20MB）
 GJCOOL_OCR_TIMEOUT=120
 OCR_MAX_UPLOAD_SIZE=20971520

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -108,9 +108,11 @@ class Settings(BaseSettings):
     # 古籍酷（gj.cool）OCR 配置
     # 注：base_url / apiid 从古籍酷「账户设置」页获取（apiid 非用户名）
     OCR_ENABLED: bool = Field(default=True, description="是否启用古籍酷 OCR 集成（凭据未填则自动不可用）")
-    GJCOOL_OCR_BASE_URL: str = Field(default="", description="古籍酷 OCR API 专属端点，如 https://xxx.gj.cool")
+    GJCOOL_OCR_BASE_URL: str = Field(default="", description="识别 worker 端点 base（/ocr_pro），如 https://ap2.jzd.cool:9043；见账户『演示』页 OCR URL")
+    GJCOOL_OCR_LOGIN_BASE_URL: str = Field(default="https://ocr.gj.cool", description="登录 base（/ocr_login，中心化认证）；留空则用 GJCOOL_OCR_BASE_URL")
     GJCOOL_OCR_APIID: str = Field(default="", description="古籍酷 apiid（账户页获取，非用户名）")
     GJCOOL_OCR_PASSWORD: SecretStr = Field(default=SecretStr(""), description="古籍酷账号密码")
+    GJCOOL_OCR_VERIFY_SSL: bool = Field(default=True, description="是否校验 worker TLS 证书（worker 证书临时过期时设 false）")
     GJCOOL_OCR_TIMEOUT: int = Field(default=120, description="单次 OCR 请求超时（秒）")
     OCR_MAX_UPLOAD_SIZE: int = Field(default=20 * 1024 * 1024, description="OCR 上传图片大小上限（字节，默认 20MB）")
     OCR_ALLOWED_CONTENT_TYPES: List[str] = Field(

--- a/backend/app/services/gjcool_ocr_service.py
+++ b/backend/app/services/gjcool_ocr_service.py
@@ -2,8 +2,13 @@
 古籍酷（gj.cool）OCR 服务
 
 封装：登录拿 access_token（内存缓存，官方有效期 24h）+ 调用古籍 OCR `/ocr_pro`。
-凭据（base_url / apiid / password）全部来自服务端配置（backend/.env），
-绝不下发到前端——前端只把图片传给我们自己的 `/api/v1/ocr/recognize`。
+凭据全部来自服务端配置（backend/.env），绝不下发到前端——前端只把图片传给我们
+自己的 `/api/v1/ocr/recognize`。
+
+注意 gj.cool 的两段式拓扑：
+- 登录是中心化的（`GJCOOL_OCR_LOGIN_BASE_URL`，默认 https://ocr.gj.cool）；
+- 识别在账户专属 worker（`GJCOOL_OCR_BASE_URL`，如 https://ap2.jzd.cool:9043，
+  端点见账户「演示」页 OCR 的 URL 下拉），登录拿到的 token 在该 worker 上通用。
 """
 from __future__ import annotations
 
@@ -40,11 +45,24 @@ class GjcoolOCRService:
         return settings.OCR_ENABLED and settings.ocr_configured
 
     @classmethod
+    def _login_url(cls) -> str:
+        base = (settings.GJCOOL_OCR_LOGIN_BASE_URL or settings.GJCOOL_OCR_BASE_URL).rstrip("/")
+        return f"{base}/ocr_login"
+
+    @classmethod
+    def _recognize_url(cls) -> str:
+        return f"{settings.GJCOOL_OCR_BASE_URL.rstrip('/')}/ocr_pro"
+
+    @classmethod
     def _get_http_client(cls) -> httpx.AsyncClient:
         if cls._http_client is None or cls._http_client.is_closed:
             cls._http_client = httpx.AsyncClient(
-                base_url=settings.GJCOOL_OCR_BASE_URL.rstrip("/"),
                 timeout=httpx.Timeout(settings.GJCOOL_OCR_TIMEOUT, connect=10.0),
+                # gj.cool 是公网 API，直连即可；不继承环境里的 HTTP(S)_PROXY / ALL_PROXY
+                # （开发机常设科学上网代理，把国内站路由进去既无必要又会触发 SOCKS 依赖问题）
+                trust_env=False,
+                # worker 端证书可能临时过期/不被信任；由配置决定是否校验
+                verify=settings.GJCOOL_OCR_VERIFY_SSL,
             )
         return cls._http_client
 
@@ -60,7 +78,7 @@ class GjcoolOCRService:
         client = cls._get_http_client()
         try:
             resp = await client.post(
-                "/ocr_login",
+                cls._login_url(),
                 data={
                     "apiid": settings.GJCOOL_OCR_APIID,
                     "password": settings.GJCOOL_OCR_PASSWORD.get_secret_value(),
@@ -107,9 +125,11 @@ class GjcoolOCRService:
 
         client = cls._get_http_client()
 
+        url = cls._recognize_url()
+
         async def _call(token: str) -> httpx.Response:
             return await client.post(
-                "/ocr_pro",
+                url,
                 headers={"Authorization": f"gjcool {token}"},
                 files={"img": (filename, img_bytes, content_type)},
             )

--- a/backend/tests/test_ocr.py
+++ b/backend/tests/test_ocr.py
@@ -9,15 +9,17 @@ from __future__ import annotations
 from app.services.gjcool_ocr_service import GjcoolOCRService
 
 
-def test_status_disabled_when_unconfigured(client):
-    """未配置凭据时 status 返回 enabled=False。"""
+def test_status_disabled_when_unconfigured(client, monkeypatch):
+    """未配置凭据时 status 返回 enabled=False（用 monkeypatch 强制未配置，避免依赖本地 .env）。"""
+    monkeypatch.setattr(GjcoolOCRService, "is_configured", lambda: False)
     resp = client.get("/api/v1/ocr/status")
     assert resp.status_code == 200
     assert resp.json() == {"enabled": False}
 
 
-def test_recognize_503_when_unconfigured(client):
+def test_recognize_503_when_unconfigured(client, monkeypatch):
     """未配置时 recognize 返回 503。"""
+    monkeypatch.setattr(GjcoolOCRService, "is_configured", lambda: False)
     resp = client.post(
         "/api/v1/ocr/recognize",
         files={"img": ("x.png", b"\x89PNG\r\n\x1a\n", "image/png")},


### PR DESCRIPTION
## 背景

PR #82 合入 OCR tab 后，实地联调（用真实 gj.cool 账号 + 高麗大藏經页图）发现两处与真实 API 拓扑不符：

1. **登录与识别不在同一 host**：登录是中心化的 `https://ocr.gj.cool/ocr_login`，识别在**账户专属 worker**（本账号是 `https://ap2.jzd.cool:9043/ocr_pro`，端点见账户「演示」页古籍OCR 的 URL 下拉）。登录拿到的 token 在 worker 上通用。原实现用单 base 调 `/ocr_pro` → **404**。
2. **worker TLS 证书可能临时过期**（本账号 worker 证书 `notAfter=2026-06-17`，已过期），需要可配置的证书校验开关才能连通。

## 改动（后端）

- `config.py`：新增 `GJCOOL_OCR_LOGIN_BASE_URL`（默认 `https://ocr.gj.cool`）与 `GJCOOL_OCR_VERIFY_SSL`（默认 `true`）；`GJCOOL_OCR_BASE_URL` 现明确指识别 worker。
- `gjcool_ocr_service.py`：登录/识别各用完整 URL（`_login_url` / `_recognize_url`）；httpx client 加 `verify=GJCOOL_OCR_VERIFY_SSL` 与 `trust_env=False`（不继承开发机的 HTTP/SOCKS 代理）。
- `.env.example`：文档化两段式拓扑 + 证书开关。
- `test_ocr.py`：未配置用例改用 `monkeypatch` 强制未配置态，不再依赖本地 `.env`（更确定性）。

## 验证

- ✅ `ruff check`（gating）、`pytest`（92 passed）
- ✅ **真实端到端**：前端 → 本平台 `POST /api/v1/ocr/recognize` → gj.cool → **HTTP 200，562 字 / 306 行**，返回古籍识别文本（夹注 `【】`）。

## 安全

凭据（apiid/password）仅在 gitignored 的 `backend/.env`，未进版本库；`.env.example` 仅占位/示例。默认 `GJCOOL_OCR_VERIFY_SSL=true`（安全默认），worker 证书过期期间在本地 `.env` 临时设 `false`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)