### PR TITLE
fix(ocr): smooth out region drag-select

### DIFF
--- a/frontend/src/pages/ocr/RegionSelectImage.tsx
+++ b/frontend/src/pages/ocr/RegionSelectImage.tsx
@@ -3,8 +3,13 @@
  *
  * 选区以「相对比例」(0~1) 表达，与渲染尺寸/分辨率无关，便于在裁剪时换算回原图像素。
  * 不框选（或框得过小视为点击）→ 选区清空（识别整图）。
+ *
+ * 性能：拖拽全程
+ *  - 只在 mousedown 时取一次 getBoundingClientRect（拖拽中图片不动，避免每次 move 强制 reflow）；
+ *  - mousemove 用 requestAnimationFrame 合并，每帧最多一次 setState（避免高频重渲染卡顿）；
+ *  - 监听挂在 window 上，光标移出图片也能跟手。
  */
-import { useRef, useState, useCallback } from 'react'
+import { useRef, useState, useCallback, useEffect } from 'react'
 
 export interface Region {
   fx: number
@@ -30,62 +35,95 @@ export default function RegionSelectImage({
   maxHeight = 420,
 }: Props) {
   const wrapRef = useRef<HTMLDivElement>(null)
+  const rectRef = useRef<DOMRect | null>(null)
   const startRef = useRef<{ fx: number; fy: number } | null>(null)
   const draftRef = useRef<Region | null>(null)
+  const pendingRef = useRef<{ fx: number; fy: number } | null>(null)
+  const rafRef = useRef<number | null>(null)
   const [draft, setDraft] = useState<Region | null>(null)
 
-  const setDraftBoth = (r: Region | null) => {
-    draftRef.current = r
-    setDraft(r)
-  }
-
-  const toFrac = useCallback((clientX: number, clientY: number) => {
-    const el = wrapRef.current
-    if (!el) return { fx: 0, fy: 0 }
-    const r = el.getBoundingClientRect()
+  const fracFromEvent = (clientX: number, clientY: number) => {
+    const r = rectRef.current
+    if (!r || r.width === 0 || r.height === 0) return { fx: 0, fy: 0 }
     return {
       fx: Math.min(1, Math.max(0, (clientX - r.left) / r.width)),
       fy: Math.min(1, Math.max(0, (clientY - r.top) / r.height)),
     }
+  }
+
+  // 把 pending 坐标合并成一次 setDraft（每帧一次）
+  const flush = useCallback(() => {
+    rafRef.current = null
+    const s = startRef.current
+    const p = pendingRef.current
+    if (!s || !p) return
+    const d: Region = {
+      fx: Math.min(s.fx, p.fx),
+      fy: Math.min(s.fy, p.fy),
+      fw: Math.abs(p.fx - s.fx),
+      fh: Math.abs(p.fy - s.fy),
+    }
+    draftRef.current = d
+    setDraft(d)
   }, [])
 
-  const onMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault()
-      const p = toFrac(e.clientX, e.clientY)
-      startRef.current = p
-      setDraftBoth({ fx: p.fx, fy: p.fy, fw: 0, fh: 0 })
-      onRegionChange(null)
+  const onWindowMove = useCallback(
+    (e: MouseEvent) => {
+      if (!startRef.current) return
+      pendingRef.current = fracFromEvent(e.clientX, e.clientY)
+      if (rafRef.current == null) {
+        rafRef.current = requestAnimationFrame(flush)
+      }
     },
-    [toFrac, onRegionChange]
+    [flush]
   )
 
-  const onMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      const s = startRef.current
-      if (!s) return
-      const p = toFrac(e.clientX, e.clientY)
-      setDraftBoth({
-        fx: Math.min(s.fx, p.fx),
-        fy: Math.min(s.fy, p.fy),
-        fw: Math.abs(p.fx - s.fx),
-        fh: Math.abs(p.fy - s.fy),
-      })
-    },
-    [toFrac]
-  )
-
-  const finish = useCallback(() => {
+  const endDrag = useCallback(() => {
     if (!startRef.current) return
     startRef.current = null
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+    window.removeEventListener('mousemove', onWindowMove)
+    window.removeEventListener('mouseup', endDrag)
     const d = draftRef.current
-    setDraftBoth(null)
+    draftRef.current = null
+    setDraft(null)
     if (d && d.fw >= MIN_FRACTION && d.fh >= MIN_FRACTION) {
       onRegionChange(d)
     } else {
       onRegionChange(null)
     }
-  }, [onRegionChange])
+  }, [onWindowMove, onRegionChange])
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      const el = wrapRef.current
+      if (!el) return
+      rectRef.current = el.getBoundingClientRect() // 每次拖拽缓存一次
+      const p = fracFromEvent(e.clientX, e.clientY)
+      startRef.current = p
+      pendingRef.current = p
+      draftRef.current = { fx: p.fx, fy: p.fy, fw: 0, fh: 0 }
+      setDraft(draftRef.current)
+      onRegionChange(null)
+      window.addEventListener('mousemove', onWindowMove)
+      window.addEventListener('mouseup', endDrag)
+    },
+    [onWindowMove, endDrag, onRegionChange]
+  )
+
+  // 卸载时清理（防止拖拽中组件被卸载导致监听泄漏）
+  useEffect(
+    () => () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+      window.removeEventListener('mousemove', onWindowMove)
+      window.removeEventListener('mouseup', endDrag)
+    },
+    [onWindowMove, endDrag]
+  )
 
   const box = draft ?? region
 
@@ -93,9 +131,6 @@ export default function RegionSelectImage({
     <div
       ref={wrapRef}
       onMouseDown={onMouseDown}
-      onMouseMove={onMouseMove}
-      onMouseUp={finish}
-      onMouseLeave={finish}
       style={{
         position: 'relative',
         display: 'inline-block',


### PR DESCRIPTION
## 问题

框选拖拽有卡顿。根因：`RegionSelectImage` 每次 `mousemove` 都 `setState` + `getBoundingClientRect()`，而 mousemove 每秒触发上百次 → 每次都触发组件重渲染 + 强制 reflow，典型的 React "拖拽画框卡顿"。

## 修复（纯交互性能，渲染输出与选区语义不变）

- **缓存矩形**：拖拽开始时取一次 `getBoundingClientRect` 并缓存（拖拽中图片不动），消除每次 move 的 reflow。
- **rAF 合并**：mousemove 只记录坐标，用 `requestAnimationFrame` 合并到每帧最多一次 `setState`。
- **window 监听**：拖拽期间把 `mousemove`/`mouseup` 挂到 `window`，光标移出图片也能跟手（顺带修掉"移出即停"）。
- 卸载时清理 raf 与监听，避免泄漏。

## 验证

- ✅ `tsc --noEmit`、`npx vite build`、`vitest`（8 passed）
- 选区比例(0~1)语义、裁剪逻辑、UI 均未变，仅事件处理更顺滑

🤖 Generated with [Claude Code](https://claude.com/claude-code)