### PR TITLE
fix(ocr): scale crop padding by selection size (no more neighbor column)

### DIFF
--- a/frontend/src/pages/ocr/cropImage.ts
+++ b/frontend/src/pages/ocr/cropImage.ts
@@ -36,9 +36,12 @@ export async function cropToFile(file: File, region: Region, name: string): Prom
     const sw = Math.max(1, Math.round(region.fw * W))
     const sh = Math.max(1, Math.round(region.fh * H))
 
-    // 牺牲边距：约选区尺寸的 6%，下限 32px、上限 200px（覆盖引擎的边距裁切 + 半截列）
-    const padX = clamp(Math.round(sw * 0.06), 32, 200)
-    const padY = clamp(Math.round(sh * 0.06), 32, 200)
+    // 牺牲边距：按选区尺寸成比例（8%），下限 12px、上限 120px。
+    // 关键是比例而非固定下限：窄选区（如单列）→ 极小边距，不会带进相邻列；
+    // 宽选区（框边可能切穿外缘列）→ 大边距，把被切的边列补全。
+    // 实测：窄单列 pad12 → 仅识别该列无邻列；宽框 pad120 → 完整救回被切的最左列。
+    const padX = clamp(Math.round(sw * 0.08), 12, 120)
+    const padY = clamp(Math.round(sh * 0.08), 12, 120)
     const x0 = clamp(sx - padX, 0, W)
     const y0 = clamp(sy - padY, 0, H)
     const x1 = clamp(sx + sw + padX, 0, W)


### PR DESCRIPTION
## 问题

框选**单列**时结果会多出**相邻一列**（框「智通…隻千古」却带出「足引其淸華…」）。根因：上个 PR(#86) 的牺牲边距用了**固定下限 32px**，对窄选区（单列宽约 60-70px）太大，扩进了邻列。

## 实测

单列(sw≈73px)：pad 0/12/24 → 单列(正确)；pad 32(旧下限) 起带邻列；pad 40 → 2 列。
而 #86 的"边缘列丢失"是**宽框切穿外缘列**、需要大边距——两者诉求相反。

## 修复：边距按选区尺寸成比例

`padding = clamp(8% × 选区边长, 12px, 120px)`：窄选区→~12px(停在列间空隙,不带邻列)；宽选区→至 120px(补全被切的边列)。

实测：单列「智通…」→ 仅该列(17字)、无邻列；宽框切列 → 仍完整救回「智通…」整列(#86 保留)。

✅ `tsc` / `vite build` / `vitest`(8 passed)，纯前端仅改裁剪几何。

🤖 Generated with [Claude Code](https://claude.com/claude-code)