### PR TITLE
[codex] prepare v0.2 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+### Security
+
+---
+
+## [0.2.0] — Pending release
+
+> Release-candidate notes for the next public release. This section should be
+> dated and linked to the GitHub Release when the `v0.2.0` tag is published.
+
+### Added
 - **古籍OCR / Ancient OCR** —— 新增「古籍OCR」tab（工作台与 CBETA 导入之间），通过古籍酷（gj.cool）OCR API 实现图片→文字；结果可编辑、复制 / 下载 .txt / 一键送入版本对勘。后端代理：gj.cool 凭据与 access_token 全在服务端，前端只上传图片。需在 `backend/.env` 配置 `GJCOOL_OCR_BASE_URL` / `GJCOOL_OCR_APIID` / `GJCOOL_OCR_PASSWORD` 后启用。
 - `examples/classical-chinese-sample/` 公开样本 + README "3 分钟试用" 章节 (#52)
 - 标准 English README + ROADMAP（`README.en.md` / `ROADMAP.en.md`）+ 顶部语言切换 (#53)
@@ -95,5 +110,6 @@ public distribution.
 - `SECRET_KEY` / `UMAMI_APP_SECRET` / `UMAMI_DB_PASSWORD` 必须从环境变量注入
 - `gitleaks` CI 步骤会扫描每次 push 的密钥泄露
 
-[Unreleased]: https://github.com/xr843/Buddhist-Text-Collation/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/xr843/Buddhist-Text-Collation/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/xr843/Buddhist-Text-Collation/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/xr843/Buddhist-Text-Collation/releases/tag/v0.1.0

--- a/ROADMAP.en.md
+++ b/ROADMAP.en.md
@@ -7,88 +7,117 @@
 
 ---
 
-## 🎯 Current
+## Current
 
-**v0.1.0** — first public open-source release (2026-05-02).
-Full notes in [`CHANGELOG.md`](CHANGELOG.md).
+**v0.2.0 release candidate** — engineering baseline, CI gates, Docker/Alembic,
+bilingual entry points, OCR integration, and documentation foundations are in
+place. Before the formal release, the remaining public-facing polish is the
+GitHub Social Preview and full-state screenshots with real demo data.
+
+Full notes live in [`CHANGELOG.md`](CHANGELOG.md).
 
 ---
 
-## 🟢 v0.2 — Polish (Soon)
+## v0.2 — Open-source Credibility
 
-**Goal**: complete the open-source baseline + first wave of quality fixes.
+**Goal**: help external researchers and contributors understand the project
+state, run samples quickly, and see deployment boundaries.
+
+### Completed
+
+| Item | Issue | Notes |
+|---|---|---|
+| `examples/` public sample + README "3-minute Try" | [#24](../../issues/24) | Merged; supports quick evaluation |
+| API docs for collab / auth / admin modules | [#31](../../issues/31) | Module docs are in place |
+| Backend ruff warnings to zero | [#27](../../issues/27) | Ruff is now a gating CI check |
+| TypeScript strict-mode regression | [#28](../../issues/28) | `tsc --noEmit` runs in CI |
+| Frontend Vitest baseline | [#29](../../issues/29) | Frontend tests are gated |
+| Frontend i18n scaffold + English skeleton | [#34](../../issues/34) | react-i18next and zh/en resource skeleton are in place |
+| GitHub Actions Node compatibility | [#33](../../issues/33) | CI actions updated |
+| python-jose / multipart CVE bumps | [#32](../../issues/32) | Security dependencies upgraded |
+| Frontend first-paint chunk diet | [#30](../../issues/30) | Route-level lazy loading and manual chunks are in place |
+| Docker Compose provisions PostgreSQL | [#55](../../pull/55) | `docker-compose up -d --build` can start the stack |
+| Alembic migrations + migration smoke CI | [#56](../../pull/56) | Covers upgrade/downgrade smoke |
+| `CITATION.cff` and citation entry | [#58](../../pull/58) | GitHub can show repository citation |
+| Algorithm-layer unit test baseline | [#60](../../pull/60) | Covers core collation algorithms |
+| Ancient OCR integration | [#88](../../pull/88) | Requires user-supplied gj.cool credentials |
+
+### Release Polish
 
 | Item | Issue | Size |
 |---|---|---|
-| `examples/` public sample + README "3-minute Try" | [#24](../../issues/24) | S |
 | GitHub Social Preview Image | [#25](../../issues/25) | XS |
-| "Full-state" feature screenshots (real data) | [#26](../../issues/26) | M (4 PR) |
-| API docs for collab / auth / admin modules | [#31](../../issues/31) | M (3 PR) |
-| Backend ruff warnings → 0 | [#27](../../issues/27) | XS |
-| TypeScript strict-mode regression | [#28](../../issues/28) | L (~10 PR) |
-| Frontend Vitest baseline | [#29](../../issues/29) | S |
-| GitHub Actions Node 24 compat | [#33](../../issues/33) | XS |
-| python-jose / multipart CVE bumps | [#32](../../issues/32) | XS |
-| Frontend first-paint chunk diet | [#30](../../issues/30) | M |
+| Full-state feature screenshots with real data | [#26](../../issues/26) | M |
+| Freeze `CHANGELOG.md` as v0.2.0 release notes | TBD | XS |
+| Publish tag / GitHub Release | TBD | XS |
 
-**Outcome**: CI strict everywhere, docs complete, overseas contributors can ramp up.
+**Outcome**: a credible v0.2 open-source release with clear docs, examples,
+CI, deployment path, and security boundaries.
 
 ---
 
-## 🟡 v0.3 — Internationalization & Accessibility (Mid)
+## v0.3 — Demo, i18n & Collaboration
 
-**Goal**: enable non-Chinese-reading scholars to use the platform directly;
-make the collaboration features work in practice.
+**Goal**: let overseas scholars try the platform directly and move
+collaboration from implemented features to usable research workflows.
 
 | Item | Issue | Size |
 |---|---|---|
-| Frontend i18n scaffold + English skeleton | [#34](../../issues/34) | M |
-| Per-page translation (one PR per page) | TBD | L (~15 PR) |
+| Reproducible demo project: public samples, expected outputs, screenshot source data | TBD | M |
+| Per-page frontend translation, one PR per page | TBD | L |
 | Collaboration module: invitation flow, annotation notifications | TBD | M |
 | Mobile / tablet responsive layout | TBD | M |
-| Smart collation-note generation (**pure rules**, no LLM dependency) | TBD | L |
-| English docs (README.en.md → docs/en/) | TBD | M |
+| Public read-only demo site | TBD | M |
+| Expanded English docs (`README.en.md` to `docs/en/`) | TBD | M |
 
 ---
 
-## 🔵 Future — Open Directions
+## v0.4 — Research-grade Exports
+
+**Goal**: make platform outputs suitable for papers, courses, digital
+humanities projects, and long-term archival workflows.
+
+| Item | Issue | Size |
+|---|---|---|
+| TEI P5 apparatus export: `app` / `lem` / `rdg` / `wit` / `sourceDesc` | TBD | L |
+| Stable DOCX academic report template | TBD | M |
+| Collation-note golden tests with fixed inputs and outputs | TBD | M |
+| Punctuation-transfer golden tests | TBD | S |
+| Multi-edition collation golden tests | TBD | M |
+| Citation metadata and export provenance | TBD | M |
+
+---
+
+## Future — Open Directions
 
 **Goal**: research directions; priority driven by user feedback and community demand.
 
-- **Batch collation CLI**: turn multi-edition PDFs/TXTs into a draft
-  collation note in one command
-- **Full TEI XML export**: TEI P5 / EpiDoc-compliant output
-- **CBETA offline snapshot**: bundle a CBETA subset, remove external-API dependency
-- **Deeper visualization**: lineage 3D, timelines, geographic overlays
-- **AI assist (optional plugin, not core)**: punctuation hints,
-  variant-adjudication suggestions — surfaced as **plugins**, never as
-  a hard dependency
-- **Public demo site**: read-only demo on fly.io / Render
-- **Academic citation**: DOI, CITATION.cff, Zenodo integration
-- **Teaching kit**: starter templates for Buddhology / classical-philology courses
+- **Batch collation CLI**: turn multi-edition PDFs/TXTs into a draft collation note in one command.
+- **CBETA offline snapshot**: bundle a CBETA subset and reduce external-API dependency.
+- **Deeper visualization**: lineage 3D, timelines, geographic overlays.
+- **AI assist (optional plugin, not core)**: punctuation hints and variant-adjudication suggestions as plugins, never as a hard dependency.
+- **Teaching kit**: starter templates for Buddhology / classical-philology courses.
+- **Zenodo / DOI integration**: formal academic publication paired with `CITATION.cff`.
 
 ---
 
-## 📐 Size Legend
+## Size Legend
 
 - **XS**: < 30 min, 1 PR
 - **S**: < 2 hours, 1 PR
-- **M**: half-day to a day, 1–3 PR
+- **M**: half-day to a day, 1-3 PR
 - **L**: multiple days, multiple PRs
 
 ---
 
-## 💡 Want to help?
+## Want to help?
 
-1. Pick an item above linked to an issue (the
-   [`good first issue`](../../issues?q=is%3Aissue+label%3A%22good+first+issue%22)
-   label is the easiest entry point)
-2. Comment "I'll take this" to avoid duplication
-3. Follow [`CONTRIBUTING.md`](CONTRIBUTING.md) to open the PR
+1. Pick an issue-linked item above, or start from [`good first issue`](../../issues?q=is%3Aissue+label%3A%22good+first+issue%22).
+2. Comment "I'll take this" to avoid duplication.
+3. Follow [`CONTRIBUTING.md`](CONTRIBUTING.md) to open the PR.
 
-If the roadmap is missing something you'd want, please open a
-[Discussion](../../discussions).
+If the roadmap is missing something you'd want, please open a [Discussion](../../discussions).
 
 ---
 
-*Last updated: 2026-05-03*
+*Last updated: 2026-07-05*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,65 +10,96 @@
 
 ---
 
-## 🎯 当前版本 / Current
+## 当前状态 / Current
 
-**v0.1.0** — 首个公开开源版本（2026-05-02）。
-完整功能见 [`CHANGELOG.md`](CHANGELOG.md)。
+**v0.2.0 release candidate** — 工程基础设施、测试门禁、Docker/Alembic、
+双语入口、OCR 集成与文档基线已经完成。正式发布前仍需要补齐公开展示素材：
+GitHub Social Preview 与主要功能"满状态"截图。
+
+完整变更见 [`CHANGELOG.md`](CHANGELOG.md)。
 
 ---
 
-## 🟢 v0.2 — 完善阶段（近期 / Soon）
+## v0.2 — 开源可信版 / Open-source Credibility
 
-**目标**：补全开源项目应有的工程基础设施 + 第一波质量改进。
+**目标**：让外部研究者和贡献者能判断项目状态、快速跑通样例、理解部署边界。
+
+### 已完成 / Completed
+
+| Item | Issue | Notes |
+|---|---|---|
+| 添加 `examples/` 公开文本样本 + README "3 分钟试用" 章节 | [#24](../../issues/24) | 已合入，支撑快速体验 |
+| 协作 / auth / admin 模块 API 文档 | [#31](../../issues/31) | 已补齐模块文档 |
+| 后端 ruff 警告清零 | [#27](../../issues/27) | CI 中 ruff 已改为 gating |
+| TypeScript 严格模式回归 | [#28](../../issues/28) | `tsc --noEmit` 已进入 CI |
+| 前端 Vitest 基础设置 | [#29](../../issues/29) | 已加入前端测试门禁 |
+| 前端 i18n 脚手架 + 英文骨架 | [#34](../../issues/34) | 已接入 react-i18next 与中英资源骨架 |
+| GitHub Actions Node 兼容升级 | [#33](../../issues/33) | CI actions 已更新 |
+| python-jose / multipart CVE 升级 | [#32](../../issues/32) | 安全依赖已升级 |
+| 前端首屏 chunk 体积优化 | [#30](../../issues/30) | 已有路由级 lazy 与 manualChunks |
+| Docker Compose 内置 PostgreSQL 主库 | [#55](../../pull/55) | `docker-compose up -d --build` 可直接起栈 |
+| Alembic 迁移与 migration smoke CI | [#56](../../pull/56) | 覆盖 upgrade/downgrade smoke |
+| `CITATION.cff` 与引用入口 | [#58](../../pull/58) | GitHub 侧栏可显示引用 |
+| 算法层单元测试基线 | [#60](../../pull/60) | 已覆盖 collation 基础算法 |
+| 古籍 OCR 集成 | [#88](../../pull/88) | 需自配 gj.cool 凭据 |
+
+### 发布前剩余 / Release Polish
 
 | Item | Issue | Size |
 |---|---|---|
-| 添加 `examples/` 公开文本样本 + README "3 分钟试用" 章节 | [#24](../../issues/24) | S |
 | GitHub Social Preview Image | [#25](../../issues/25) | XS |
-| 主要功能"满状态"截图（带真实数据） | [#26](../../issues/26) | M (4 PR) |
-| 协作 / auth / admin 模块 API 文档 | [#31](../../issues/31) | M (3 PR) |
-| 后端 ruff 警告清零 | [#27](../../issues/27) | XS |
-| TypeScript 严格模式回归 | [#28](../../issues/28) | L (~10 PR) |
-| 前端 Vitest 基础设置 | [#29](../../issues/29) | S |
-| GitHub Actions Node 24 兼容 | [#33](../../issues/33) | XS |
-| python-jose / multipart CVE 升级 | [#32](../../issues/32) | XS |
-| 前端首屏 chunk 体积优化 | [#30](../../issues/30) | M |
+| 主要功能"满状态"截图（带真实数据） | [#26](../../issues/26) | M |
+| `CHANGELOG.md` 固化为 v0.2.0 release notes | TBD | XS |
+| 发布 tag / GitHub Release | TBD | XS |
 
-**预期产出**：CI 全部 strict 模式、文档完备、海外贡献者能上手。
+**预期产出**：一个可信的 v0.2 开源版本，文档、示例、CI、部署路径与安全边界都足够清楚。
 
 ---
 
-## 🟡 v0.3 — 国际化与可达性（中期 / Mid）
+## v0.3 — 演示、国际化与协作 / Demo, i18n & Collaboration
 
-**目标**：让海外学者也能直接用，让协作机制真正跑起来。
+**目标**：让海外学者能直接试用，让协作机制从"已实现"走向"可用于真实项目"。
 
 | Item | Issue | Size |
 |---|---|---|
-| 前端 i18n 脚手架 + 英文骨架 | [#34](../../issues/34) | M |
-| 前端逐 page 翻译（每 page 一个 PR） | TBD | L (~15 PR) |
+| 可复现 demo project：公开样本、预期输出、截图数据源 | TBD | M |
+| 前端逐 page 翻译（每 page 一个 PR） | TBD | L |
 | 协作模块完善：成员邀请流程、批注通知 | TBD | M |
 | 移动端 / 平板适配（响应式布局） | TBD | M |
-| 校勘记智能生成：基于异文类型自动生成草稿（**纯规则**，不引入 LLM 依赖） | TBD | L |
-| 文档英文版（README.en.md → docs/en/）| TBD | M |
+| 公开只读 Demo Site | TBD | M |
+| 文档英文版扩展（`README.en.md` → `docs/en/`） | TBD | M |
 
 ---
 
-## 🔵 Future — 探索方向 / Open
+## v0.4 — 研究级导出 / Research-grade Exports
+
+**目标**：让平台输出能进入论文、课程、数字人文项目和长期归档流程。
+
+| Item | Issue | Size |
+|---|---|---|
+| TEI P5 apparatus 导出增强：`app` / `lem` / `rdg` / `wit` / `sourceDesc` | TBD | L |
+| DOCX 学术报告模板稳定化 | TBD | M |
+| 校勘记 golden tests：固定输入、固定输出 | TBD | M |
+| 标点迁移 golden tests | TBD | S |
+| 多版本对勘 golden tests | TBD | M |
+| 引用元数据与导出 provenance | TBD | M |
+
+---
+
+## Future — 探索方向 / Open Directions
 
 **目标**：研究方向探索；优先级看用户反馈与社区需求决定。
 
-- **批量校勘流水线**：CLI 工具把多版本 PDF/TXT 一键跑成校勘记草稿
-- **TEI XML 全套导出**：完全符合 TEI P5 / EpiDoc 规范的输出
-- **CBETA 离线快照**：内置一份 CBETA 子集，去除外部 API 依赖
-- **可视化深化**：版本谱系 3D / 时间轴 / 地理分布联动
-- **AI 辅助（可选插件，非核心）**：标点建议、异文判取建议——以**插件**形态接入，不进核心依赖
-- **公开实例 / Demo Site**：在 fly.io / Render 部署一个只读演示
-- **学术引用规范**：DOI 申请、CITATION.cff、Zenodo 集成
-- **教学场景包**：面向佛学/古文献课程的示例项目模板
+- **批量校勘流水线**：CLI 工具把多版本 PDF/TXT 一键跑成校勘记草稿。
+- **CBETA 离线快照**：内置一份 CBETA 子集，去除外部 API 依赖。
+- **可视化深化**：版本谱系 3D / 时间轴 / 地理分布联动。
+- **AI 辅助（可选插件，非核心）**：标点建议、异文判取建议；以插件形态接入，不进核心依赖。
+- **教学场景包**：面向佛学/古文献课程的示例项目模板。
+- **Zenodo / DOI 集成**：配合 `CITATION.cff` 做正式学术发布。
 
 ---
 
-## 📐 大小标记 / Size legend
+## 大小标记 / Size Legend
 
 - **XS**: < 30 分钟，1 个 PR
 - **S**: < 2 小时，1 个 PR
@@ -77,14 +108,14 @@
 
 ---
 
-## 💡 想贡献？ / Want to help?
+## 想贡献？ / Want to help?
 
-1. 选一个上面带 issue 链接的条目（推荐 [`good first issue`](../../issues?q=is%3Aissue+label%3A%22good+first+issue%22) 标签）
-2. 在 issue 下回复 "I'll take this" 防撞
-3. 按 [`CONTRIBUTING.md`](CONTRIBUTING.md) 流程开 PR
+1. 选一个上面带 issue 链接的条目，或从 [`good first issue`](../../issues?q=is%3Aissue+label%3A%22good+first+issue%22) 开始。
+2. 在 issue 下回复 "I'll take this" 防撞。
+3. 按 [`CONTRIBUTING.md`](CONTRIBUTING.md) 流程开 PR。
 
 如果发现路线图缺了你想要的能力，欢迎开 [Discussion](../../discussions) 提议。
 
 ---
 
-*最后更新 / Last updated: 2026-05-02*
+*最后更新 / Last updated: 2026-07-05*

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,7 +1,7 @@
-# 佛典标点与校勘研究平台
+# 佛典标点与校勘研究平台（历史设计档案）
 
-[![Version](https://img.shields.io/badge/version-2.10-blue.svg)](https://github.com)
-[![License](https://img.shields.io/badge/license-TBD-lightgrey.svg)](#开源协议)
+[![Docs](https://img.shields.io/badge/docs-historical_archive-lightgrey.svg)](../README.md)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](../LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/)
 [![React](https://img.shields.io/badge/react-18+-blue.svg)](https://react.dev/)
 [![Docker](https://img.shields.io/badge/docker-支持-blue.svg)](#docker部署推荐)
@@ -13,7 +13,7 @@
 
 佛经古籍标点比较与校勘研究平台。提供标点版本对比、两版本对勘、多版本对勘、版本谱系分析、经论注疏对读等功能，帮助研究者高效完成佛典文献的校勘工作。
 
-> **关于本文档**：这是历史完整版中文文档（V1 → V2.10 演进记录）。它**保留了若干已在 v0.1.0 开源版下线的功能介绍**（最显著的是"OCR 数字化工作台"——开源版未集成第三方付费 OCR 服务）。请以仓库根目录的 `README.md` 为当前功能权威说明；本文档作为**研究背景与设计思路参考**保留。
+> **关于本文档**：这是历史完整版中文文档（V1 → V2.10 演进记录），作为**研究背景与设计思路参考**保留。它可能包含已下线、已重做、需要自配第三方凭据，或仅在早期内部版本存在的功能说明。请以仓库根目录的 [`README.md`](../README.md)、[`ROADMAP.md`](../ROADMAP.md) 与 [`CHANGELOG.md`](../CHANGELOG.md) 为当前功能、版本和部署边界的权威说明。
 
 ## 核心功能
 
@@ -728,15 +728,15 @@ kill -9 $(lsof -ti:8000)
 
 ---
 
-### v0.1.0 (当前公开版本 / current open-source release) — 2026-05-02
+### v0.1.0 (首个公开版本 / first open-source release) — 2026-05-02
 首个开源版本，从内部 V2.10 整理而来。
 
 **核心模块（开源版包含）：**
 - ✅ 标点版本对比、两/多版本对勘、注疏对读、版本谱系、标点迁移
 - ✅ CBETA 集成、协作、导出（TXT / DOCX / TEI / CSV）
 
-**移除的模块（开源版**不**包含）：**
-- ❌ OCR 数字化工作台（依赖第三方付费 API gj.cool）
+**首发时移除的模块（v0.1.0 初始开源版**不**包含）：**
+- ❌ OCR 数字化工作台（依赖第三方付费 API gj.cool；后续版本已以自配凭据方式重新接入，当前状态请看根目录 `README.md` 与 `CHANGELOG.md`）
 
 详见仓库根目录 [`CHANGELOG.md`](../CHANGELOG.md) 与 [`README.md`](../README.md)。
 
@@ -763,7 +763,7 @@ kill -9 $(lsof -ti:8000)
 
 ## 开源协议
 
-待补充（README 中的 License 徽章为占位）
+本项目采用 [GNU Affero General Public License v3.0](../LICENSE)。如本文档中的历史描述与仓库根目录的 `README.md` 或 `LICENSE` 不一致，请以后者为准。
 
 ## 致谢
 

--- a/docs/superpowers/plans/2026-07-05-v0.2-docs-release.md
+++ b/docs/superpowers/plans/2026-07-05-v0.2-docs-release.md
@@ -1,0 +1,89 @@
+# v0.2 Docs Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prepare release-facing documentation for a v0.2 release candidate.
+
+**Architecture:** This is a documentation-only change. The root roadmap communicates status, the changelog carries release notes, and the historical Chinese README is clarified as archival background.
+
+**Tech Stack:** Markdown, Git.
+
+---
+
+### Task 1: Update Roadmap Status
+
+**Files:**
+- Modify: `ROADMAP.md`
+- Modify: `ROADMAP.en.md`
+
+- [ ] **Step 1: Rewrite the current-version section**
+
+Set the current status to `v0.2.0 - release candidate` and explain that the final release waits on screenshots/social preview.
+
+- [ ] **Step 2: Split v0.2 into completed and remaining items**
+
+Move completed issue-linked work into a completed table and keep #25/#26 as remaining release polish items.
+
+- [ ] **Step 3: Reframe v0.3**
+
+Describe v0.3 as demo, internationalization, collaboration, and accessibility work.
+
+### Task 2: Promote Changelog Candidate Section
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Keep an empty Unreleased section**
+
+Leave headings for future `Added`, `Changed`, `Fixed`, and `Security` entries.
+
+- [ ] **Step 2: Move existing notes to `0.2.0 - Pending release`**
+
+Preserve all existing entries and make clear that this is not a published tag yet.
+
+- [ ] **Step 3: Update compare links**
+
+Add a `0.2.0` comparison link and make `Unreleased` compare from `v0.2.0` to `HEAD`.
+
+### Task 3: Clarify Historical Chinese README
+
+**Files:**
+- Modify: `docs/README.zh-CN.md`
+
+- [ ] **Step 1: Replace stale badges**
+
+Use a historical-design badge and AGPL-3.0 license badge instead of `version-2.10` and `license-TBD`.
+
+- [ ] **Step 2: Strengthen archive notice**
+
+Make the notice explicit that this file is historical and may include retired/internal material.
+
+- [ ] **Step 3: Fix license section**
+
+Replace the placeholder license text with an AGPL-3.0 pointer to `../LICENSE`.
+
+### Task 4: Verify
+
+**Files:**
+- Inspect: `ROADMAP.md`
+- Inspect: `ROADMAP.en.md`
+- Inspect: `CHANGELOG.md`
+- Inspect: `docs/README.zh-CN.md`
+
+- [ ] **Step 1: Search for stale placeholders**
+
+Run: `rg -n "license-TBD|待补充|v0\\.1\\.0.*当前|first public open-source release|最后更新 / Last updated: 2026-05-02|Last updated: 2026-05-03" ROADMAP.md ROADMAP.en.md CHANGELOG.md docs/README.zh-CN.md`
+
+Expected: no output.
+
+- [ ] **Step 2: Check Markdown diff whitespace**
+
+Run: `git diff --check`
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 3: Review changed files**
+
+Run: `git diff -- ROADMAP.md ROADMAP.en.md CHANGELOG.md docs/README.zh-CN.md`
+
+Expected: changes are limited to v0.2 release documentation status and historical-doc clarification.

--- a/docs/superpowers/specs/2026-07-05-v0.2-docs-release-design.md
+++ b/docs/superpowers/specs/2026-07-05-v0.2-docs-release-design.md
@@ -1,0 +1,32 @@
+# v0.2 Docs Release Design
+
+## Goal
+
+Prepare the repository documentation for a v0.2 release-candidate state without changing application code, database schema, or runtime behavior.
+
+## Scope
+
+This work updates release-facing documentation only:
+
+- `ROADMAP.md`
+- `ROADMAP.en.md`
+- `CHANGELOG.md`
+- `docs/README.zh-CN.md`
+
+It does not create a git tag, publish a GitHub Release, close issues, alter screenshots, or change product behavior.
+
+## Design
+
+`ROADMAP.md` and `ROADMAP.en.md` should reflect the current implementation state instead of showing v0.2 as entirely planned work. Completed v0.2 items are marked done, remaining public-facing polish items stay open, and the next phase is framed around demo credibility, collaboration, internationalization, and research-grade exports.
+
+`CHANGELOG.md` should keep an empty `Unreleased` section for future work and move the accumulated release notes into a dated `0.2.0 - Pending release` section. This avoids claiming a release has been published while still giving maintainers a clean candidate changelog.
+
+`docs/README.zh-CN.md` should be clearly labeled as a historical design archive. Its stale version and license badges should not contradict the root README. The license section should point to the AGPL-3.0 repository license and warn readers that current feature truth lives in the root README.
+
+## Verification
+
+Verification is text-focused:
+
+- Inspect the modified Markdown around changed sections.
+- Search for stale `license-TBD`, `待补充`, and outdated roadmap status wording.
+- Run `git diff --check` to catch whitespace errors.


### PR DESCRIPTION
## Summary

- Reframe the Chinese and English roadmaps around the current v0.2.0 release-candidate state.
- Move accumulated changelog entries into a `0.2.0 - Pending release` section while keeping an empty `Unreleased` section for future work.
- Clarify `docs/README.zh-CN.md` as a historical design archive and replace stale license/version placeholders.
- Add the design and implementation notes used for this documentation pass under `docs/superpowers/`.

## Impact

This is documentation-only. It does not change application code, database schema, runtime configuration, or deployment behavior.

## Validation

- `rg -n "license-TBD|待补充|v0\\.1\\.0.*当前|当前公开版本|current open-source release|first public open-source release|最后更新 / Last updated: 2026-05-02|Last updated: 2026-05-03|version-2\\.10" ROADMAP.md ROADMAP.en.md CHANGELOG.md docs/README.zh-CN.md`
- `git diff HEAD^ --check`
