### PR TITLE
[codex] chore(deps): require pytest-asyncio 0.26

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -42,5 +42,5 @@ loguru==0.7.3
 
 # 测试
 pytest>=9.0.3,<10  # CVE-2025-71176
-pytest-asyncio>=0.24.0
+pytest-asyncio>=0.26.0
 pytest-cov>=5.0.0


### PR DESCRIPTION
## What changed
- Raise the backend `pytest-asyncio` lower bound from `>=0.24.0` to `>=0.26.0`.

## Why
This carries forward Dependabot PR #73 without resolving its stale branch conflicts against the updated dependency baseline.

## Validation
- `.venv/bin/python -m pip install -r requirements.txt && .venv/bin/python -m pip_audit -r requirements.txt` -> no known vulnerabilities found
- `.venv/bin/python -m ruff check app/ --output-format=github && .venv/bin/python -m compileall -q app/`
- `.venv/bin/python -m pytest tests/ -v --no-header` -> 92 passed
