### PR TITLE
[codex] docs: update v0.2 polish status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and [Semantic Versioning](https://semver.org/).
 > dated and linked to the GitHub Release when the `v0.2.0` tag is published.
 
 ### Added
+- GitHub Social Preview asset and filled-state feature screenshots for the README / repository preview (#97, #99-#102).
 - **古籍OCR / Ancient OCR** —— 新增「古籍OCR」tab（工作台与 CBETA 导入之间），通过古籍酷（gj.cool）OCR API 实现图片→文字；结果可编辑、复制 / 下载 .txt / 一键送入版本对勘。后端代理：gj.cool 凭据与 access_token 全在服务端，前端只上传图片。需在 `backend/.env` 配置 `GJCOOL_OCR_BASE_URL` / `GJCOOL_OCR_APIID` / `GJCOOL_OCR_PASSWORD` 后启用。
 - `examples/classical-chinese-sample/` 公开样本 + README "3 分钟试用" 章节 (#52)
 - 标准 English README + ROADMAP（`README.en.md` / `ROADMAP.en.md`）+ 顶部语言切换 (#53)
@@ -50,11 +51,11 @@ and [Semantic Versioning](https://semver.org/).
 - JWT `datetime.utcnow()` (naive) → `datetime.now(timezone.utc)` (aware)；非 UTC 服务器上 token 过期时间会偏差一个本地时区偏移 (#59)
 
 ### Security
-- 见上面 #50 / #51 / #62。剩余 1 条 dev-only Vite/esbuild moderate alert（需 vite 5→8 大版本）已记入 follow-up。
+- 见上面 #50 / #51 / #62。
+- 前端依赖安全刷新：Vite、ECharts、Undici、form-data、React Router、Babel、esbuild 等告警已清理；`npm audit --audit-level=low` 为 0。
+- 后端依赖安全刷新：`PyPDF2` 迁移到 `pypdf`，并提升 FastAPI / Starlette / pytest / python-jose / email-validator / pytest-asyncio 版本下限；`pip-audit -r backend/requirements.txt` 为 0。
 
 ### 待办 / Planned (未来 PR)
-- vite 5 → 8 大版本（清最后一条 dev-only alert）
-- pytest 9 升级（先验 pytest-asyncio matrix）
 - `services/punctuation_analysis/` 与 `services/text_compare.py` 测试覆盖
 - 前端 `: any` / `@ts-ignore` 类型债清理（约 76 处，按文件拆 PR）
 - 拆分 3000-行 `MultiCollation.tsx` / 1146-行 `cbeta_service.py`

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@
 
 ![标点迁移](docs/screenshots/feature-punctuation-transfer.png)
 
-> 📷 更多截图（带真实数据的差异高亮 / 校勘记 / 版本谱系图等）正在筹备中。
-> More screenshots (highlighted diffs, collation notes, lineage graph, etc.) coming soon.
+> 📷 更多截图与预览素材见 [`docs/screenshots/`](docs/screenshots/)。
+> More screenshots and preview assets live in [`docs/screenshots/`](docs/screenshots/).
 >
 > 想帮忙的朋友可以提交 PR 到 [`docs/screenshots/`](docs/screenshots/)。
 > Contributions welcome via PR.

--- a/ROADMAP.en.md
+++ b/ROADMAP.en.md
@@ -10,9 +10,9 @@
 ## Current
 
 **v0.2.0 release candidate** — engineering baseline, CI gates, Docker/Alembic,
-bilingual entry points, OCR integration, and documentation foundations are in
-place. Before the formal release, the remaining public-facing polish is the
-GitHub Social Preview and full-state screenshots with real demo data.
+bilingual entry points, OCR integration, public-facing assets, and dependency
+security cleanup are in place. Before the formal release, only the tag /
+GitHub Release workflow remains.
 
 Full notes live in [`CHANGELOG.md`](CHANGELOG.md).
 
@@ -41,14 +41,14 @@ state, run samples quickly, and see deployment boundaries.
 | `CITATION.cff` and citation entry | [#58](../../pull/58) | GitHub can show repository citation |
 | Algorithm-layer unit test baseline | [#60](../../pull/60) | Covers core collation algorithms |
 | Ancient OCR integration | [#88](../../pull/88) | Requires user-supplied gj.cool credentials |
+| GitHub Social Preview Image | [#25](../../issues/25) | Social preview assets are in place |
+| Full-state feature screenshots with real data | [#26](../../issues/26) | README now uses filled-state screenshots |
+| Freeze `CHANGELOG.md` as v0.2.0 release notes | [#96](../../pull/96) | Date and release link will be added when the tag is published |
 
 ### Release Polish
 
 | Item | Issue | Size |
 |---|---|---|
-| GitHub Social Preview Image | [#25](../../issues/25) | XS |
-| Full-state feature screenshots with real data | [#26](../../issues/26) | M |
-| Freeze `CHANGELOG.md` as v0.2.0 release notes | TBD | XS |
 | Publish tag / GitHub Release | TBD | XS |
 
 **Outcome**: a credible v0.2 open-source release with clear docs, examples,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,8 +13,8 @@
 ## 当前状态 / Current
 
 **v0.2.0 release candidate** — 工程基础设施、测试门禁、Docker/Alembic、
-双语入口、OCR 集成与文档基线已经完成。正式发布前仍需要补齐公开展示素材：
-GitHub Social Preview 与主要功能"满状态"截图。
+双语入口、OCR 集成、公开展示素材与安全依赖清理已经完成。正式发布前仅剩
+tag / GitHub Release 流程。
 
 完整变更见 [`CHANGELOG.md`](CHANGELOG.md)。
 
@@ -42,14 +42,14 @@ GitHub Social Preview 与主要功能"满状态"截图。
 | `CITATION.cff` 与引用入口 | [#58](../../pull/58) | GitHub 侧栏可显示引用 |
 | 算法层单元测试基线 | [#60](../../pull/60) | 已覆盖 collation 基础算法 |
 | 古籍 OCR 集成 | [#88](../../pull/88) | 需自配 gj.cool 凭据 |
+| GitHub Social Preview Image | [#25](../../issues/25) | 已加入社交预览资源 |
+| 主要功能"满状态"截图（带真实数据） | [#26](../../issues/26) | README 顶部已替换为真实截图 |
+| `CHANGELOG.md` 固化为 v0.2.0 release notes | [#96](../../pull/96) | 待发布 tag 时补日期与链接 |
 
 ### 发布前剩余 / Release Polish
 
 | Item | Issue | Size |
 |---|---|---|
-| GitHub Social Preview Image | [#25](../../issues/25) | XS |
-| 主要功能"满状态"截图（带真实数据） | [#26](../../issues/26) | M |
-| `CHANGELOG.md` 固化为 v0.2.0 release notes | TBD | XS |
 | 发布 tag / GitHub Release | TBD | XS |
 
 **预期产出**：一个可信的 v0.2 开源版本，文档、示例、CI、部署路径与安全边界都足够清楚。


### PR DESCRIPTION
## What changed
- Move completed v0.2 polish items (#25, #26, #96) from the remaining list into the completed roadmap table.
- Update the current roadmap status: public assets and dependency security cleanup are done; only tag / GitHub Release remains.
- Refresh README screenshot wording and remove stale changelog follow-ups for Vite/esbuild and pytest 9.

## Validation
- `git diff --check`
- stale wording scan for old release-polish/security follow-up text
