### PR TITLE
[codex] docs: finalize v0.2.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@ and [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [0.2.0] — Pending release
+## [0.2.0] — 2026-07-05
 
-> Release-candidate notes for the next public release. This section should be
-> dated and linked to the GitHub Release when the `v0.2.0` tag is published.
+Second public release focused on open-source credibility: runnable examples,
+CI hardening, deployment docs, filled-state screenshots, OCR integration, and
+dependency security cleanup.
 
 ### Added
 - GitHub Social Preview asset and filled-state feature screenshots for the README / repository preview (#97, #99-#102).
@@ -112,5 +113,5 @@ public distribution.
 - `gitleaks` CI 步骤会扫描每次 push 的密钥泄露
 
 [Unreleased]: https://github.com/xr843/Buddhist-Text-Collation/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/xr843/Buddhist-Text-Collation/compare/v0.1.0...HEAD
+[0.2.0]: https://github.com/xr843/Buddhist-Text-Collation/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/xr843/Buddhist-Text-Collation/releases/tag/v0.1.0

--- a/ROADMAP.en.md
+++ b/ROADMAP.en.md
@@ -9,10 +9,9 @@
 
 ## Current
 
-**v0.2.0 release candidate** — engineering baseline, CI gates, Docker/Alembic,
+**v0.2.0 is published** — engineering baseline, CI gates, Docker/Alembic,
 bilingual entry points, OCR integration, public-facing assets, and dependency
-security cleanup are in place. Before the formal release, only the tag /
-GitHub Release workflow remains.
+security cleanup are in place.
 
 Full notes live in [`CHANGELOG.md`](CHANGELOG.md).
 
@@ -43,13 +42,13 @@ state, run samples quickly, and see deployment boundaries.
 | Ancient OCR integration | [#88](../../pull/88) | Requires user-supplied gj.cool credentials |
 | GitHub Social Preview Image | [#25](../../issues/25) | Social preview assets are in place |
 | Full-state feature screenshots with real data | [#26](../../issues/26) | README now uses filled-state screenshots |
-| Freeze `CHANGELOG.md` as v0.2.0 release notes | [#96](../../pull/96) | Date and release link will be added when the tag is published |
+| Freeze `CHANGELOG.md` as v0.2.0 release notes | [#96](../../pull/96) | Finalized with the release date |
 
-### Release Polish
+### Release Status
 
 | Item | Issue | Size |
 |---|---|---|
-| Publish tag / GitHub Release | TBD | XS |
+| v0.2.0 tag / GitHub Release | TBD | Done |
 
 **Outcome**: a credible v0.2 open-source release with clear docs, examples,
 CI, deployment path, and security boundaries.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,9 +12,8 @@
 
 ## 当前状态 / Current
 
-**v0.2.0 release candidate** — 工程基础设施、测试门禁、Docker/Alembic、
-双语入口、OCR 集成、公开展示素材与安全依赖清理已经完成。正式发布前仅剩
-tag / GitHub Release 流程。
+**v0.2.0 已发布** — 工程基础设施、测试门禁、Docker/Alembic、
+双语入口、OCR 集成、公开展示素材与安全依赖清理已经完成。
 
 完整变更见 [`CHANGELOG.md`](CHANGELOG.md)。
 
@@ -44,13 +43,13 @@ tag / GitHub Release 流程。
 | 古籍 OCR 集成 | [#88](../../pull/88) | 需自配 gj.cool 凭据 |
 | GitHub Social Preview Image | [#25](../../issues/25) | 已加入社交预览资源 |
 | 主要功能"满状态"截图（带真实数据） | [#26](../../issues/26) | README 顶部已替换为真实截图 |
-| `CHANGELOG.md` 固化为 v0.2.0 release notes | [#96](../../pull/96) | 待发布 tag 时补日期与链接 |
+| `CHANGELOG.md` 固化为 v0.2.0 release notes | [#96](../../pull/96) | 已定稿并标注发布日期 |
 
-### 发布前剩余 / Release Polish
+### 发布状态 / Release Status
 
 | Item | Issue | Size |
 |---|---|---|
-| 发布 tag / GitHub Release | TBD | XS |
+| v0.2.0 tag / GitHub Release | TBD | Done |
 
 **预期产出**：一个可信的 v0.2 开源版本，文档、示例、CI、部署路径与安全边界都足够清楚。
 


### PR DESCRIPTION
## What changed
- Finalize the v0.2.0 changelog section with the 2026-07-05 release date.
- Update v0.2.0 compare link to target the release tag.
- Mark the roadmap release status as published.

## Validation
- `git diff --check`
- stale release-state wording scan across `CHANGELOG.md`, `ROADMAP.md`, and `ROADMAP.en.md`
